### PR TITLE
feat: support translations

### DIFF
--- a/projects/admin/src/i18n.ts
+++ b/projects/admin/src/i18n.ts
@@ -1,0 +1,3 @@
+export default {
+  en: {},
+};

--- a/projects/admin/src/lib/admin.module.ts
+++ b/projects/admin/src/lib/admin.module.ts
@@ -16,6 +16,7 @@ import { CheckboxDisplayComponent } from './components/checkbox-display/checkbox
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { Lab900FormsModule } from '@lab900/forms';
 import { DialogModule } from '@lab900/ui';
+import { TranslateModule } from '@ngx-translate/core';
 
 @NgModule({
   declarations: [
@@ -38,6 +39,7 @@ import { DialogModule } from '@lab900/ui';
     Lab900FormsModule,
     DialogModule,
     MatCheckboxModule,
+    TranslateModule.forChild(),
   ],
   exports: [AdminPageComponent],
 })

--- a/projects/admin/src/lib/components/admin-table/admin-table.component.html
+++ b/projects/admin/src/lib/components/admin-table/admin-table.component.html
@@ -5,7 +5,7 @@
                              [ngStyle]="column?.overviewOptions?.displayOptions?.maxColumnWidth &&
                                 { 'max-width': column?.overviewOptions?.displayOptions?.maxColumnWidth }"
             class="table__header__cell">
-                {{column.title }} </mat-header-cell>
+                {{ column.title | translate }} </mat-header-cell>
             <mat-cell *matCellDef="let element"
                       [ngStyle]="column?.overviewOptions?.displayOptions?.maxColumnWidth &&
                                 { 'max-width': column?.overviewOptions?.displayOptions?.maxColumnWidth }"

--- a/projects/admin/src/lib/components/checkbox-display/checkbox-display.component.html
+++ b/projects/admin/src/lib/components/checkbox-display/checkbox-display.component.html
@@ -1,1 +1,3 @@
-<mat-checkbox *ngIf="data !== undefined" disabled="true"  [checked]="data"></mat-checkbox>
+<mat-checkbox *ngIf="data !== undefined" disabled="true"  [checked]="data">
+  {{fieldType.title | translate}}
+</mat-checkbox>

--- a/projects/forms/src/assets/i18n.ts
+++ b/projects/forms/src/assets/i18n.ts
@@ -1,0 +1,20 @@
+export default {
+  en: {
+    'forms.error.number-required': 'A valid number is required.',
+    'forms.error.required': 'This is required.',
+    'forms.error.minlength': 'This field should contain at least {{minLength}} characters.',
+    'forms.error.maxlength': 'This field should contain at most {{minLength}} characters.',
+    'forms.error.min': 'This should be at least {{min}}.',
+    'forms.error.max': 'This should be at most {{max}}.',
+    'forms.error.generic': 'Field is invalid.',
+  },
+  nl: {
+    'forms.error.number-required': 'Een geldig getal is verplicht.',
+    'forms.error.required': 'Dit is verplicht.',
+    'forms.error.minlength': 'Dit moet minstens {{minLength}} karakters bevatten.',
+    'forms.error.maxlength': 'Dit moet minstens {{minLength}} karakters bevatten.',
+    'forms.error.min': 'Dit moet minstens {{min}} zijn.',
+    'forms.error.max': 'Dit mag maximaal {{max}} zijn.',
+    'forms.error.generic': 'Deze waarde is ongeldig.',
+  },
+};

--- a/projects/forms/src/lib/components/form-fields/autocomplete-field/autocomplete-field.component.html
+++ b/projects/forms/src/lib/components/form-fields/autocomplete-field/autocomplete-field.component.html
@@ -2,7 +2,7 @@
     <mat-label translate>{{ schema.title }}</mat-label>
     <input matInput type="text" [matAutocomplete]="auto" (input)="inputChanged($event)" placeholder="{{ placeholder | translate }}" [formControlName]="schema.attribute" [required]="options?.required">
     <mat-hint *ngIf="hint" translate>{{ hint }}</mat-hint>
-    <mat-error *ngIf="!valid" translate>{{getErrorMessage()}}</mat-error>
+    <mat-error *ngIf="!valid">{{ getErrorMessage() | async }}</mat-error>
     <mat-icon matSuffix>search</mat-icon>
     <mat-autocomplete #auto="matAutocomplete" [displayWith]="options.displayInputFn">
         <mat-option *ngFor="let option of filteredOptions | async" [value]="option">

--- a/projects/forms/src/lib/components/form-fields/autocomplete-field/autocomplete-field.component.ts
+++ b/projects/forms/src/lib/components/form-fields/autocomplete-field/autocomplete-field.component.ts
@@ -2,6 +2,7 @@ import { Component, HostBinding } from '@angular/core';
 import { FormComponent } from '../../../models/IFormComponent';
 import { AutocompleteOptions } from '../../../models/FormField';
 import { Observable, isObservable, of } from 'rxjs';
+import { TranslateService } from '@ngx-translate/core';
 
 @Component({
   selector: 'lab900-autocomplete-field',
@@ -12,6 +13,10 @@ export class AutocompleteFieldComponent extends FormComponent<AutocompleteOption
   public classList = 'lab900-form-field';
 
   public filteredOptions: Observable<any[]>;
+
+  constructor(translateService: TranslateService) {
+    super(translateService);
+  }
 
   public inputChanged($event: Event) {
     const res = this.options.getOptionsFn(($event.target as any).value);

--- a/projects/forms/src/lib/components/form-fields/button-toggle-field/button-toggle-field.component.html
+++ b/projects/forms/src/lib/components/form-fields/button-toggle-field/button-toggle-field.component.html
@@ -1,5 +1,5 @@
 <div [formGroup]="group" [hidden]="hide" class="button-toggle-field mat-form-field-wrapper">
-    <div *ngIf="schema.title"><mat-label [translate]="schema.title"></mat-label></div>
+    <div *ngIf="schema.title"><mat-label>{{ schema.title | translate }}</mat-label></div>
     <mat-button-toggle-group [formControlName]="schema.attribute" [required]="options?.required">
         <mat-button-toggle *ngFor="let value of options?.values" [value]="value.value">
             <ng-container *ngIf="value.label">
@@ -8,5 +8,5 @@
             <lab900-icon *ngIf="value.icon" [icon]="value.icon"></lab900-icon>
         </mat-button-toggle>
     </mat-button-toggle-group>
-    <mat-error class="mat-form-field-subscript-wrapper" *ngIf="!valid" [translate]="getErrorMessage()"></mat-error>
+    <mat-error class="mat-form-field-subscript-wrapper" *ngIf="!valid">{{ getErrorMessage() | async }}</mat-error>
 </div>

--- a/projects/forms/src/lib/components/form-fields/button-toggle-field/button-toggle-field.component.ts
+++ b/projects/forms/src/lib/components/form-fields/button-toggle-field/button-toggle-field.component.ts
@@ -1,4 +1,5 @@
 import { Component, HostBinding } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
 import { FormComponent } from '../../../models/IFormComponent';
 import { ButtonToggleFieldOptions } from '../../../models/FormField';
 
@@ -9,4 +10,8 @@ import { ButtonToggleFieldOptions } from '../../../models/FormField';
 export class ButtonToggleFieldComponent extends FormComponent<ButtonToggleFieldOptions> {
   @HostBinding('class')
   public classList = 'lab900-form-field';
+
+  constructor(translateService: TranslateService) {
+    super(translateService);
+  }
 }

--- a/projects/forms/src/lib/components/form-fields/checkbox-field/checkbox-field.component.css
+++ b/projects/forms/src/lib/components/form-fields/checkbox-field/checkbox-field.component.css
@@ -1,0 +1,13 @@
+:host {
+    width: 100%;
+}
+
+mat-label {
+    margin-right: 20px;
+}
+
+.subscript-wrapper {
+  font-size: 75%;
+  height: 1em;
+  margin-top: .6666666667em;
+}

--- a/projects/forms/src/lib/components/form-fields/checkbox-field/checkbox-field.component.html
+++ b/projects/forms/src/lib/components/form-fields/checkbox-field/checkbox-field.component.html
@@ -1,6 +1,9 @@
 <div [formGroup]="group" [hidden]="hide">
-    <mat-label translate>{{schema.title}}</mat-label>
-    <mat-checkbox [formControlName]="schema.attribute" [required]="options?.required"></mat-checkbox>
-    <mat-hint *ngIf="hint" translate>{{ hint }}</mat-hint>
-    <mat-error *ngIf="!valid" translate>{{getErrorMessage()}}</mat-error>
+    <mat-checkbox [formControlName]="schema.attribute" [indeterminate]="indeterminate" [required]="options?.required">
+      {{schema.title | translate}}
+    </mat-checkbox>
+    <div class="subscript-wrapper" [@transitionMessages]="valid ? 'void' : 'enter'">
+        <mat-hint *ngIf="hint" translate>{{ hint }}</mat-hint>
+        <mat-error *ngIf="!valid">{{ getErrorMessage() | async }}</mat-error>
+    </div>
 </div>

--- a/projects/forms/src/lib/components/form-fields/checkbox-field/checkbox-field.component.ts
+++ b/projects/forms/src/lib/components/form-fields/checkbox-field/checkbox-field.component.ts
@@ -1,11 +1,23 @@
 import { Component, HostBinding } from '@angular/core';
 import { FormComponent } from '../../../models/IFormComponent';
+import { TranslateService } from '@ngx-translate/core';
+import { matFormFieldAnimations } from '@angular/material/form-field';
 
 @Component({
   selector: 'lab900-checkbox-field',
   templateUrl: './checkbox-field.component.html',
+  styleUrls: ['./checkbox-field.component.css'],
+  animations: [matFormFieldAnimations.transitionMessages],
 })
 export class CheckboxFieldComponent extends FormComponent {
   @HostBinding('class')
   public classList = 'lab900-form-field';
+
+  constructor(translateService: TranslateService) {
+    super(translateService);
+  }
+
+  get indeterminate(): boolean {
+    return this.group.get(this.schema.attribute).value === null;
+  }
 }

--- a/projects/forms/src/lib/components/form-fields/date-field/date-field.component.html
+++ b/projects/forms/src/lib/components/form-fields/date-field/date-field.component.html
@@ -10,5 +10,5 @@
     <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
     <mat-datepicker #picker></mat-datepicker>
     <mat-hint *ngIf="hint" translate>{{ hint }}</mat-hint>
-    <mat-error *ngIf="!valid" translate>{{getErrorMessage()}}</mat-error>
+    <mat-error *ngIf="!valid">{{ getErrorMessage() | async }}</mat-error>
 </mat-form-field>

--- a/projects/forms/src/lib/components/form-fields/date-field/date-field.component.ts
+++ b/projects/forms/src/lib/components/form-fields/date-field/date-field.component.ts
@@ -1,5 +1,6 @@
 import { Component, HostBinding } from '@angular/core';
 import { FormComponent } from '../../../models/IFormComponent';
+import { TranslateService } from '@ngx-translate/core';
 
 @Component({
   selector: 'lab900-date-field',
@@ -8,4 +9,7 @@ import { FormComponent } from '../../../models/IFormComponent';
 export class DateFieldComponent extends FormComponent {
   @HostBinding('class')
   public classList = 'lab900-form-field';
+  constructor(translateService: TranslateService) {
+    super(translateService);
+  }
 }

--- a/projects/forms/src/lib/components/form-fields/file-field/file-field.component.html
+++ b/projects/forms/src/lib/components/form-fields/file-field/file-field.component.html
@@ -4,5 +4,5 @@
     <mat-icon matSuffix class="flex">folder</mat-icon>
     <mat-icon *ngIf="!fileField.empty" matSuffix (click)="fileField.clear($event)">close</mat-icon>
     <mat-hint *ngIf="hint" translate>{{ hint }}</mat-hint>
-    <mat-error *ngIf="!valid" translate>{{getErrorMessage()}}</mat-error>
+    <mat-error *ngIf="!valid">{{ getErrorMessage() | async }}</mat-error>
 </mat-form-field>

--- a/projects/forms/src/lib/components/form-fields/file-field/file-field.component.ts
+++ b/projects/forms/src/lib/components/form-fields/file-field/file-field.component.ts
@@ -1,5 +1,6 @@
 import { Component, HostBinding } from '@angular/core';
 import { FormComponent } from '../../../models/IFormComponent';
+import { TranslateService } from '@ngx-translate/core';
 
 @Component({
   selector: 'lab900-file-field',
@@ -9,4 +10,7 @@ import { FormComponent } from '../../../models/IFormComponent';
 export class FileFieldComponent extends FormComponent {
   @HostBinding('class')
   public classList = 'lab900-form-field';
+  constructor(translateService: TranslateService) {
+    super(translateService);
+  }
 }

--- a/projects/forms/src/lib/components/form-fields/icon-field/icon-field.component.ts
+++ b/projects/forms/src/lib/components/form-fields/icon-field/icon-field.component.ts
@@ -1,6 +1,7 @@
 import { Component, HostBinding } from '@angular/core';
 import { FormComponent } from '../../../models/IFormComponent';
 import { IconFieldOptions } from '../../../models/FormField';
+import { TranslateService } from '@ngx-translate/core';
 
 @Component({
   selector: 'lab900-icon-field',
@@ -10,4 +11,8 @@ import { IconFieldOptions } from '../../../models/FormField';
 export class IconFieldComponent extends FormComponent<IconFieldOptions> {
   @HostBinding('class')
   public classList = 'lab900-form-field';
+
+  constructor(translateService: TranslateService) {
+    super(translateService);
+  }
 }

--- a/projects/forms/src/lib/components/form-fields/input-field/input-field.component.html
+++ b/projects/forms/src/lib/components/form-fields/input-field/input-field.component.html
@@ -1,5 +1,5 @@
 <mat-form-field [formGroup]="group" [hidden]="hide" class="input-field">
-    <mat-label [translate]="schema.title"></mat-label>
+    <mat-label>{{ schema.title | translate }}</mat-label>
     <input
         matInput
         #input
@@ -9,9 +9,9 @@
         [required]="options?.required"
         [readonly]="options?.readOnly"
     >
-    <mat-hint *ngIf="hint" [translate]="hint"></mat-hint>
+    <mat-hint *ngIf="hint">{{ hint | translate }}</mat-hint>
     <mat-hint align="end" *ngIf="options?.maxLength">{{ input.value?.length || 0 }}/{{ options?.maxLength }}</mat-hint>
-    <mat-error *ngIf="!valid" [translate]="getErrorMessage()"></mat-error>
+    <mat-error *ngIf="!valid">{{ getErrorMessage() | async }}</mat-error>
     <lab900-icon [icon]="schema.icon" *ngIf="schema?.icon?.position === 'left'" matPrefix class="input-field__icon-left"></lab900-icon>
     <lab900-icon [icon]="schema.icon" *ngIf="schema?.icon?.position === 'right'" matSuffix ></lab900-icon>
 </mat-form-field>

--- a/projects/forms/src/lib/components/form-fields/input-field/input-field.component.ts
+++ b/projects/forms/src/lib/components/form-fields/input-field/input-field.component.ts
@@ -1,6 +1,7 @@
 import { Component, HostBinding } from '@angular/core';
 import { FormComponent } from '../../../models/IFormComponent';
 import { InputFieldOptions } from '../../../models/FormField';
+import { TranslateService } from '@ngx-translate/core';
 
 @Component({
   selector: 'lab900-input-field',
@@ -10,6 +11,10 @@ import { InputFieldOptions } from '../../../models/FormField';
 export class InputFieldComponent extends FormComponent<InputFieldOptions> {
   @HostBinding('class')
   public classList = 'lab900-form-field';
+
+  constructor(translateService: TranslateService) {
+    super(translateService);
+  }
 
   public get inputType(): 'text' | 'number' | 'email' | 'password' {
     return (this.options && this.options.type) || 'text';

--- a/projects/forms/src/lib/components/form-fields/radio-buttons-field/radio-buttons-field.component.html
+++ b/projects/forms/src/lib/components/form-fields/radio-buttons-field/radio-buttons-field.component.html
@@ -4,6 +4,6 @@
         <mat-radio-button *ngFor="let value of options?.values" [value]="value.value">{{ value.label | translate }}</mat-radio-button>
     </mat-radio-group>
     <div class="radio-buttons-field__error">
-        <mat-error *ngIf="!valid" [translate]="getErrorMessage()"></mat-error>
+        <mat-error *ngIf="!valid">{{ getErrorMessage() | async }}</mat-error>
     </div>
 </div>

--- a/projects/forms/src/lib/components/form-fields/radio-buttons-field/radio-buttons-field.component.ts
+++ b/projects/forms/src/lib/components/form-fields/radio-buttons-field/radio-buttons-field.component.ts
@@ -1,4 +1,5 @@
 import { Component, HostBinding } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
 import { FormComponent } from '../../../models/IFormComponent';
 import { RadioButtonsFieldOptions } from '../../../models/FormField';
 
@@ -9,4 +10,8 @@ import { RadioButtonsFieldOptions } from '../../../models/FormField';
 export class RadioButtonsFieldComponent extends FormComponent<RadioButtonsFieldOptions> {
   @HostBinding('class')
   public classList = 'lab900-form-field';
+
+  constructor(translateService: TranslateService) {
+    super(translateService);
+  }
 }

--- a/projects/forms/src/lib/components/form-fields/range-slider-field/range-slider-field.component.html
+++ b/projects/forms/src/lib/components/form-fields/range-slider-field/range-slider-field.component.html
@@ -11,6 +11,6 @@
         [required]="options?.required"
     ></lab900-mat-range-slider-field>
     <div class="radio-buttons-field__error">
-        <mat-error *ngIf="!valid" [translate]="getErrorMessage()"></mat-error>
+        <mat-error *ngIf="!valid">{{ getErrorMessage() | async }}</mat-error>
     </div>
 </div>

--- a/projects/forms/src/lib/components/form-fields/range-slider-field/range-slider-field.component.ts
+++ b/projects/forms/src/lib/components/form-fields/range-slider-field/range-slider-field.component.ts
@@ -1,4 +1,5 @@
 import { Component, HostBinding } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
 import { FormComponent } from '../../../models/IFormComponent';
 import { RangeSliderFieldOptions } from '../../../models/FormField';
 
@@ -9,4 +10,8 @@ import { RangeSliderFieldOptions } from '../../../models/FormField';
 export class RangeSliderFieldComponent extends FormComponent<RangeSliderFieldOptions> {
   @HostBinding('class')
   public classList = 'lab900-form-field';
+
+  constructor(translateService: TranslateService) {
+    super(translateService);
+  }
 }

--- a/projects/forms/src/lib/components/form-fields/repeater-field/repeater-field.component.ts
+++ b/projects/forms/src/lib/components/form-fields/repeater-field/repeater-field.component.ts
@@ -3,6 +3,7 @@ import { FormComponent } from '../../../models/IFormComponent';
 import { FormArray } from '@angular/forms';
 import { RepeaterFieldOptions } from '../../../models/FormField';
 import { Lab900FormBuilderService } from '../../../services/form-builder.service';
+import { TranslateService } from '@ngx-translate/core';
 
 @Component({
   selector: 'lab900-repeater-field',
@@ -33,8 +34,8 @@ export class RepeaterFieldComponent extends FormComponent<RepeaterFieldOptions> 
     return this.group.get(this.schema.attribute) as FormArray;
   }
 
-  public constructor(private fb: Lab900FormBuilderService) {
-    super();
+  public constructor(private fb: Lab900FormBuilderService, translateService: TranslateService) {
+    super(translateService);
   }
 
   public ngOnInit(): void {

--- a/projects/forms/src/lib/components/form-fields/select-field/select-field.component.html
+++ b/projects/forms/src/lib/components/form-fields/select-field/select-field.component.html
@@ -4,5 +4,5 @@
         <mat-option *ngFor="let item of values" [value]="item.key" translate>{{item.value}}</mat-option>
     </mat-select>
     <mat-hint *ngIf="hint" translate>{{ hint }}</mat-hint>
-    <mat-error *ngIf="!valid" translate>{{getErrorMessage()}}</mat-error>
+    <mat-error *ngIf="!valid">{{ getErrorMessage() | async }}</mat-error>
 </mat-form-field>

--- a/projects/forms/src/lib/components/form-fields/select-field/select-field.component.ts
+++ b/projects/forms/src/lib/components/form-fields/select-field/select-field.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit, HostBinding } from '@angular/core';
 import { FormComponent } from '../../../models/IFormComponent';
 import { SelectFieldOptions } from '../../../models/FormField';
+import { TranslateService } from '@ngx-translate/core';
 
 @Component({
   selector: 'lab900-select-field',
@@ -11,6 +12,10 @@ export class SelectFieldComponent extends FormComponent<SelectFieldOptions> impl
   public classList = 'lab900-form-field';
 
   public values: { key: string; value: string }[];
+
+  constructor(translateService: TranslateService) {
+    super(translateService);
+  }
 
   public ngOnInit(): void {
     this.values = (this.options && this.options.values) || [];

--- a/projects/forms/src/lib/components/form-fields/textarea-field/textarea-field.component.html
+++ b/projects/forms/src/lib/components/form-fields/textarea-field/textarea-field.component.html
@@ -3,5 +3,5 @@
     <textarea matInput #input placeholder="{{ placeholder | translate }}" [formControlName]="schema.attribute" [required]="options?.required"></textarea>
     <mat-hint *ngIf="hint" translate>{{ hint }}</mat-hint>
     <mat-hint align="end" *ngIf="options?.maxLength">{{ input.value?.length || 0 }}/{{ options?.maxLength }}</mat-hint>
-    <mat-error *ngIf="!valid" translate>{{ getErrorMessage() }}</mat-error>
+    <mat-error *ngIf="!valid">{{ getErrorMessage() | async }}</mat-error>
 </mat-form-field>

--- a/projects/forms/src/lib/components/form-fields/textarea-field/textarea-field.component.ts
+++ b/projects/forms/src/lib/components/form-fields/textarea-field/textarea-field.component.ts
@@ -1,4 +1,5 @@
 import { Component, HostBinding } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
 import { FormComponent } from '../../../models/IFormComponent';
 
 @Component({
@@ -9,4 +10,8 @@ import { FormComponent } from '../../../models/IFormComponent';
 export class TextareaFieldComponent extends FormComponent {
   @HostBinding('class')
   public classList = 'lab900-form-field';
+
+  constructor(translateService: TranslateService) {
+    super(translateService);
+  }
 }

--- a/projects/forms/src/lib/components/form-fields/unknown-field/unknown-field.component.ts
+++ b/projects/forms/src/lib/components/form-fields/unknown-field/unknown-field.component.ts
@@ -1,5 +1,6 @@
 import { Component, HostBinding } from '@angular/core';
 import { FormComponent } from '../../../models/IFormComponent';
+import { TranslateService } from '@ngx-translate/core';
 
 @Component({
   selector: 'lab900-unknown-field',
@@ -11,4 +12,7 @@ import { FormComponent } from '../../../models/IFormComponent';
 export class UnknownFieldComponent extends FormComponent {
   @HostBinding('class')
   public classList = 'lab900-form-field';
+  constructor(translateService: TranslateService) {
+    super(translateService);
+  }
 }

--- a/projects/forms/src/lib/components/form-fields/wysiwyg-field/wysiwyg-field.component.scss
+++ b/projects/forms/src/lib/components/form-fields/wysiwyg-field/wysiwyg-field.component.scss
@@ -1,0 +1,9 @@
+/*@import "../../../../../src/assets/vendor/quill.core.css";
+@import "../../../../../src/assets/vendor/quill.bubble.css";
+@import "../../../../../src/assets/vendor/quill.snow.css";*/
+
+.subscript-wrapper {
+  font-size: 75%;
+  height: 1em;
+  margin-top: .6666666667em;
+}

--- a/projects/forms/src/lib/components/form-fields/wysiwyg-field/wysiwyg-field.component.ts
+++ b/projects/forms/src/lib/components/form-fields/wysiwyg-field/wysiwyg-field.component.ts
@@ -1,7 +1,9 @@
 import { Component, OnInit, HostBinding } from '@angular/core';
+import { matFormFieldAnimations } from '@angular/material/form-field';
 import { FormComponent } from '../../../models/IFormComponent';
 import { AngularEditorConfig } from '@kolkov/angular-editor';
 import { WysiwygFieldOptions } from '../../../models/FormField';
+import { TranslateService } from '@ngx-translate/core';
 
 @Component({
   selector: 'lab900-wysiwyg-field',
@@ -10,12 +12,18 @@ import { WysiwygFieldOptions } from '../../../models/FormField';
       <angular-editor [formControlName]="schema.attribute" [config]="editorConfig"></angular-editor>
     </div>
   `,
+  styleUrls: ['./wysiwyg-field.component.scss'],
+  animations: [matFormFieldAnimations.transitionMessages],
 })
 export class WysiwygFieldComponent extends FormComponent<WysiwygFieldOptions> implements OnInit {
   @HostBinding('class')
   public classList = 'lab900-form-field';
 
   public editorConfig: AngularEditorConfig;
+
+  constructor(translateService: TranslateService) {
+    super(translateService);
+  }
 
   public ngOnInit(): void {
     this.editorConfig = {

--- a/projects/forms/src/lib/components/form-row/form-row.component.ts
+++ b/projects/forms/src/lib/components/form-row/form-row.component.ts
@@ -1,4 +1,5 @@
 import { Component, HostBinding } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
 import { FormComponent } from '../../models/IFormComponent';
 import { FieldOptions } from '../../models/FormField';
 
@@ -10,6 +11,10 @@ import { FieldOptions } from '../../models/FormField';
 export class FormRowComponent extends FormComponent<FieldOptions> {
   @HostBinding('class')
   public classList = 'lab900-form-field';
+
+  constructor(translateService: TranslateService) {
+    super(translateService);
+  }
 
   colspan(options: FieldOptions) {
     return options == null || !options.colspan

--- a/projects/forms/src/lib/forms.module.ts
+++ b/projects/forms/src/lib/forms.module.ts
@@ -93,6 +93,7 @@ const customFields = [
     HttpClientModule,
     TranslateModule,
     MatButtonToggleModule,
+    TranslateModule.forChild(),
   ],
   exports: [FormContainerComponent, FormDialogDirective],
 })

--- a/projects/forms/src/lib/models/FormField.ts
+++ b/projects/forms/src/lib/models/FormField.ts
@@ -19,10 +19,9 @@ export interface FieldOptions {
   pattern?: RegExp;
 
   /**
-   * User-friendly representation of the regex. For invalid input,
-   * the user will receive an error message like "Please enter a valid ${regexName}."
+   * Translation key for the error to be shown when the pattern validation failed.
    */
-  patternTitle?: string;
+  patternError?: string;
 
   visibleFn?: (item: IFormComponent<any>) => boolean;
 }

--- a/projects/forms/src/lib/models/IFormComponent.ts
+++ b/projects/forms/src/lib/models/IFormComponent.ts
@@ -1,6 +1,8 @@
 import { FormGroup } from '@angular/forms';
 import { FormField, FieldOptions } from './FormField';
 import { Input, Injectable } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
+import { Observable } from 'rxjs';
 
 export interface IFormComponent<T extends FieldOptions> {
   schema: FormField<T>;
@@ -14,6 +16,8 @@ export abstract class FormComponent<T extends FieldOptions = FieldOptions> imple
 
   @Input()
   public schema: FormField<T>;
+
+  constructor(private translateService: TranslateService) {}
 
   public get valid(): boolean {
     return this.group.get(this.schema.attribute).valid;
@@ -35,37 +39,39 @@ export abstract class FormComponent<T extends FieldOptions = FieldOptions> imple
     return this.schema && this.schema.options && this.schema.options.placeholder;
   }
 
-  public getErrorMessage(): string {
+  public getErrorMessage(): Observable<string> {
     const field = this.group.get(this.schema.attribute);
-    let message = `Field is invalid.`;
+    let message = this.translateService.get('forms.error.generic');
+
     Object.keys(field.errors).forEach((key: string) => {
       if (field.hasError(key)) {
         if (this.schema.errorMessages && Object.keys(this.schema.errorMessages).includes(key)) {
-          message = this.schema.errorMessages[key];
+          message = this.translateService.get(this.schema.errorMessages[key]);
         } else {
           message = this.getDefaultErrorMessage(key);
         }
       }
     });
+
     return message;
   }
 
-  private getDefaultErrorMessage(key: string): string {
+  private getDefaultErrorMessage(key: string): Observable<string> {
     switch (key) {
       case 'required':
-        return `A value is required.`;
+        return this.translateService.get('forms.error.required');
       case 'minlength':
-        return `This field should contain at least ${this.options.minLength} characters.`;
+        return this.translateService.get('forms.error.minlength', this.schema.options);
       case 'maxlength':
-        return `This field should contain at most ${this.options.maxLength} characters.`;
+        return this.translateService.get('forms.error.maxlength', this.schema.options);
       case 'min':
-        return `This should be at least ${this.options.min}.`;
+        return this.translateService.get('forms.error.min', this.schema.options);
       case 'max':
-        return `This should be at most ${this.options.max}.`;
+        return this.translateService.get('forms.error.max', this.schema.options);
       case 'pattern':
-        return `Please enter a valid ${this.options.patternTitle}.`;
+        return this.translateService.get(this.schema.options.patternError ?? 'forms.error.generic', this.schema.options);
       default:
-        return `Field is invalid.`;
+        return this.translateService.get('forms.error.generic');
     }
   }
 }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -4,6 +4,20 @@
             <img src="../assets/images/logo-duo-dark.svg">
             <h1>Angular Libraries</h1>
         </div>
+
+        <div class="fill-remaining-space"></div>
+
+        <div class="language-selector">
+            <mat-form-field floatLabel="never">
+                <mat-label>{{ 'language' | translate }}</mat-label>
+                <mat-select (valueChange)="languageChanged($event)" [(value)]="language">
+                    <mat-option *ngFor="let lang of languages" [value]="lang">
+                        {{ 'languages.' + lang | translate }}
+                    </mat-option>
+                </mat-select>
+            </mat-form-field>
+        </div>
+
     </mat-toolbar>
     <div class="lab900-showcase__content">
         <mat-drawer-container class="example-container">

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -29,6 +29,14 @@
 			font-weight: normal;
 		}
 	}
+
+	.language-selector {
+		font-size: .75rem;
+	}
+}
+
+.fill-remaining-space {
+  flex: 1 1 auto;
 }
 
 main {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,14 +1,34 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { NavItemGroup } from 'projects/ui/src/lib/nav-list/models/nav-item.model';
 import { showcaseFormsNavItems } from './modules/showcase-forms/showcase-forms.nav-items';
 import { showcaseUiNavItems } from './modules/showcase-ui/showcase-ui.nav-items';
 import { showcaseAdminNavItems } from './modules/showcase-admin/showcase-admin.nav-items';
+import { TranslateService } from '@ngx-translate/core';
 
 @Component({
   selector: 'lab900-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss'],
 })
-export class AppComponent {
+export class AppComponent implements OnInit {
   public navItemsGroups: NavItemGroup[] = [...showcaseFormsNavItems, ...showcaseUiNavItems, ...showcaseAdminNavItems];
+
+  languages = ['en', 'nl'];
+  language = 'en';
+
+  constructor(private translateService: TranslateService) {
+    // this language will be used as a fallback when a translation isn't found in the current language
+    this.translateService.setDefaultLang('en');
+
+    // the lang to use, if the lang isn't available, it will use the current loader to get them
+    this.translateService.use('en');
+  }
+
+  ngOnInit(): void {
+    this.language = this.translateService.currentLang;
+  }
+
+  languageChanged(language: string) {
+    this.translateService.use(language);
+  }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,27 +1,44 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatSelectModule } from '@angular/material/select';
 import { Lab900FormsModule } from '../../projects/forms/src/lib/forms.module';
 
 import { AppComponent } from './app.component';
 import { AppRoutingModule } from './app-routing.module';
 import { SharedModule } from './modules/shared/shared.module';
-import { TranslateModule } from '@ngx-translate/core';
 import { MarkdownModule } from 'ngx-markdown';
+import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
+import { MergingTranslateLoader } from './utils/merging-translate-loader';
+import { HttpClient } from '@angular/common/http';
+
+export function TranslationLoaderFactory(http: HttpClient) {
+  return new MergingTranslateLoader(http, './assets/i18n/', '.json');
+}
 
 @NgModule({
   declarations: [AppComponent],
   imports: [
     BrowserModule,
     BrowserAnimationsModule,
+    MatFormFieldModule,
+    MatSelectModule,
     AppRoutingModule,
     SharedModule,
-    TranslateModule.forRoot(),
     MarkdownModule.forRoot(),
     Lab900FormsModule.forRoot({
       formField: {
         appearance: 'outline',
       },
+    }),
+    TranslateModule.forRoot({
+      loader: {
+        provide: TranslateLoader,
+        useFactory: TranslationLoaderFactory,
+        deps: [HttpClient],
+      },
+      defaultLanguage: 'en',
     }),
   ],
   providers: [],

--- a/src/app/utils/merging-translate-loader.ts
+++ b/src/app/utils/merging-translate-loader.ts
@@ -1,0 +1,26 @@
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { HttpClient } from '@angular/common/http';
+import { TranslateLoader } from '@ngx-translate/core';
+
+import formsTranslations from '../../../projects/forms/src/assets/i18n';
+
+/**
+ * Custom ngx-translate translation loader that combines translation files from subprojects with translations from this
+ * (root) project. The root project can override and extend translations as needed.
+ */
+export class MergingTranslateLoader implements TranslateLoader {
+  constructor(private http: HttpClient, public prefix: string = '/assets/i18n/', public suffix: string = '.json') {}
+
+  /**
+   * Combines translations from subprojects with dynamically loaded translations/overrides for this project.
+   */
+  public getTranslation(lang: string): Observable<object> {
+    return this.http.get(`${this.prefix}${lang}${this.suffix}`).pipe(
+      map((translations) => ({
+        ...formsTranslations[lang],
+        ...translations,
+      })),
+    );
+  }
+}

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1,0 +1,31 @@
+{
+  "forms.error.somethingelse": "123",
+  "language": "Language",
+  "languages.en": "English",
+  "languages.nl": "Dutch",
+  "label": {
+    "first-name": "First Name",
+    "last-name": "Last Name",
+    "open-dialog-form": "Open dialog form",
+    "open-dialog-form-prefilled": "Open dialog form with prefilled data",
+    "email": "Email",
+    "email-error": "Please enter a valid email address.",
+    "number": "Number",
+    "attachment": "Attachment",
+    "posted-on": "Posted On",
+    "published": "Published",
+    "pizza-toppings": "Pizza Toppings",
+    "cheese": "Cheese",
+    "tomato": "Tomato",
+    "must-agree": "I like pizza",
+    "pizza-error": "That is not a valid answer."
+  },
+  "content": {
+    "buttons": "Buttons",
+    "form-element": "Form Element",
+    "forms": "Forms",
+    "admin": "Admin",
+    "ui": "UI",
+    "form-title": "Please enter your information below."
+  }
+}

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -1,0 +1,39 @@
+{
+  "language": "Taal",
+  "languages.en": "Engels",
+  "languages.nl": "Nederlands",
+  "label": {
+    "first-name": "Voornaam",
+    "last-name": "Achternaam",
+    "open-dialog-form": "Open vensterformulier",
+    "open-dialog-form-prefilled": "Open ingevuld vensterformulier",
+    "email": "E-mailadres",
+    "email-error": "Dat ziet er geen geldig e-mailadres uit.",
+    "number": "Getal",
+    "attachment": "Bijlage",
+    "posted-on": "Geplaatst op",
+    "published": "Gepubliceerd",
+    "pizza-toppings": "Pizzabeleg",
+    "cheese": "Kaas",
+    "tomato": "Tomaat",
+    "must-agree": "Ik eet graag pizza",
+    "pizza-error": "Dat kan niet."
+  },
+  "content": {
+    "buttons": "Knoppen",
+    "form-element": "Formulier-element",
+    "forms": "Formulieren",
+    "admin": "Admin",
+    "ui": "UI",
+    "form-title": "Vul je gegevens hieronder in."
+  },
+
+  "Published": "Gepubliceerd",
+  "Title": "Titel",
+  "Subtitle": "Ondertitel",
+  "Author": "Auteur",
+  "Posted On": "Geplaatst op",
+  "Posted By": "Geplaatst door",
+  "Content": "Inhoud",
+  "Background": "Achtergrond"
+}


### PR DESCRIPTION
This adds the features from #7 again to the current version. Rebasing was a lot of work so best not to wait too long to merge this in ;)

A few things from that PR that might not be (fully) included in this one:

- Error message styling and animation for checkbox and Wysiwyg fields
- Support for indeterminate state in the checkbox field
- Error messages: in #7 I had made the error message an observable stream but it looks like the implementation has already changed now. I'd done that to fix the issue where the error message wouldn't update when the error *changed* (e.g. you empty a number field and then type text in it; it should change from "this field is required" to "this field should be a number"). Using the observable will also be more efficient instead of running the `getErrorMessage()` function on every render. Anyways, that's maybe a potential future performance improvement.
- I didn't translate the labels in the showcase