### PR TITLE
Merger fix nested objects wrong arrow active

### DIFF
--- a/projects/ui/package.json
+++ b/projects/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lab900/ui",
-  "version": "2.1.88",
+  "version": "2.1.90",
   "author": "Lab900 <info@lab900.com> (https://lab900.com)",
   "licens": "MIT",
   "peerDependencies": {

--- a/projects/ui/src/lib/merger/components/merger/merger.component.html
+++ b/projects/ui/src/lib/merger/components/merger/merger.component.html
@@ -31,7 +31,7 @@
                 ></mat-radio-button>
             </div>
         </div>
-        <div *ngFor="let config of schema" class="lab900-merger__row" fxLayoutAlign="space-between stretch">
+        <div *ngFor="let config of schema; let i = index" class="lab900-merger__row" fxLayoutAlign="space-between stretch">
             <lab900-merger-item
                 [active]="selected === 'left'"
                 [config]="config"
@@ -40,7 +40,7 @@
             ></lab900-merger-item>
             <div class="lab900-merger__row__icon">
                 <mat-icon
-                    (click)="toggleActive(config)"
+                    (click)="toggleActive(config, i)"
                     *ngIf="compare(config)"
                     [ngClass]="{'not-active': !config.active, 'rotate': selected !== 'right'}"
                     color="primary"

--- a/projects/ui/src/lib/merger/components/merger/merger.component.ts
+++ b/projects/ui/src/lib/merger/components/merger/merger.component.ts
@@ -76,19 +76,18 @@ export class Lab900MergerComponent<T> implements OnInit, OnChanges {
     return this.selected === 'right' ? this.rightObject.data : this.leftObject.data;
   }
 
-  public toggleActive(config: MergeConfig<T>): void {
+  public toggleActive(config: MergeConfig<T>, index: number): void {
     const base: T = { ...this.getBase(!config.active) };
     if (config?.nestedObject) {
       config.nestedObject.forEach((c: MergeConfigBase) => {
-        const attribute = config.attribute ? config.attribute : c.attribute;
+        const attribute = config?.attribute ?? c.attribute;
         this.result[attribute] = base[attribute];
       });
     } else {
       this.result[config.attribute] = base[config.attribute];
     }
 
-    const configIndex = this.schema.findIndex((s) => s.attribute === config.attribute);
-    this.schema[configIndex] = { ...this.schema[configIndex], active: !config.active };
+    this.schema[index] = { ...this.schema[index], active: !config.active };
   }
 
   public ngOnChanges(changes: SimpleChanges): void {

--- a/projects/ui/src/lib/merger/models/merge-config.model.ts
+++ b/projects/ui/src/lib/merger/models/merge-config.model.ts
@@ -3,7 +3,7 @@ import { Type } from '@angular/core';
 import { CustomComponent } from '../abstracts/custom-component.abstract';
 
 export interface MergeConfigBase {
-  attribute: string;
+  attribute?: string;
   label?: string;
   formatter?: (data: any) => Observable<string> | string;
 }

--- a/src/app/modules/showcase-ui/examples/merger-example/config/merger-schema-example.ts
+++ b/src/app/modules/showcase-ui/examples/merger-example/config/merger-schema-example.ts
@@ -6,19 +6,6 @@ import { MergerDataExample } from '../models/merger-data-example.model';
 
 export const mergerSchemaExample: MergeConfig<MergerDataExample>[] = [
   {
-    attribute: '',
-    nestedObject: [
-      {
-        attribute: 'name',
-        label: 'label.last-name',
-      },
-      {
-        attribute: 'firstName',
-        label: 'label.first-name',
-      },
-    ],
-  },
-  {
     attribute: 'address',
     nestedObject: [
       {
@@ -53,5 +40,17 @@ export const mergerSchemaExample: MergeConfig<MergerDataExample>[] = [
   {
     attribute: 'text',
     component: CustomExampleComponent,
+  },
+  {
+    nestedObject: [
+      {
+        attribute: 'name',
+        label: 'label.last-name',
+      },
+      {
+        attribute: 'firstName',
+        label: 'label.first-name',
+      },
+    ],
   },
 ];


### PR DESCRIPTION
When having nested objects the wrong arrow was active because there was a bug in the find, fixed it by passing the index to the function.