### PR TITLE
Release/forms 2.2.0

### DIFF
--- a/deployForms.bat
+++ b/deployForms.bat
@@ -1,5 +1,5 @@
 cd projects/forms/
-call npm version patch
+call npm version preminor --preid=beta
 cd ../..
 call npm run build:forms:prod
 cd dist/@lab900/forms

--- a/deployForms.sh
+++ b/deployForms.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 cd projects/forms/
-npm version 2.2.0-beta.4
+npm version 2.2.0-beta.6
 cd ../..
 npm run build:forms:prod
 cd dist/@lab900/forms

--- a/deployForms.sh
+++ b/deployForms.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 cd projects/forms/
-npm version patch
+npm version prepatch --preid=beta
 cd ../..
 npm run build:forms:prod
 cd dist/@lab900/forms
-npm publish
+npm publish --tag beta

--- a/deployForms.sh
+++ b/deployForms.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 cd projects/forms/
-npm version 2.2.0-beta.6
+npm version 2.2.0-beta.8
 cd ../..
 npm run build:forms:prod
 cd dist/@lab900/forms

--- a/deployForms.sh
+++ b/deployForms.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 cd projects/forms/
-npm version 2.2.0-beta.8
+npm version 2.2.0-beta.11
 cd ../..
 npm run build:forms:prod
 cd dist/@lab900/forms

--- a/deployForms.sh
+++ b/deployForms.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 cd projects/forms/
-npm version 2.2.0-beta.3
+npm version 2.2.0-beta.4
 cd ../..
 npm run build:forms:prod
 cd dist/@lab900/forms

--- a/deployForms.sh
+++ b/deployForms.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 cd projects/forms/
-npm version 2.2.0-beta.11
+npm version patch
 cd ../..
 npm run build:forms:prod
 cd dist/@lab900/forms
-npm publish --tag beta
+npm publish

--- a/deployForms.sh
+++ b/deployForms.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 cd projects/forms/
-npm version preminor --preid=beta
+npm version 2.2.0-beta.3
 cd ../..
 npm run build:forms:prod
 cd dist/@lab900/forms

--- a/deployForms.sh
+++ b/deployForms.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 cd projects/forms/
-npm version prepatch --preid=beta
+npm version preminor --preid=beta
 cd ../..
 npm run build:forms:prod
 cd dist/@lab900/forms

--- a/projects/forms/_theming.scss
+++ b/projects/forms/_theming.scss
@@ -26,4 +26,14 @@
       display: none !important;
     }
   }
+
+  .lab900-readonly-field {
+    padding-bottom: 1.34375em;
+
+    &__label {
+      font-weight: bold;
+      margin-bottom: 0.75rem;
+      display: block;
+    }
+  }
 }

--- a/projects/forms/package.json
+++ b/projects/forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lab900/forms",
-  "version": "2.2.0-beta.3",
+  "version": "2.2.0-beta.4",
   "author": "Lab900 <info@lab900.com> (https://lab900.com)",
   "licens": "MIT",
   "peerDependencies": {

--- a/projects/forms/package.json
+++ b/projects/forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lab900/forms",
-  "version": "2.1.40",
+  "version": "2.1.41",
   "author": "Lab900 <info@lab900.com> (https://lab900.com)",
   "licens": "MIT",
   "peerDependencies": {

--- a/projects/forms/package.json
+++ b/projects/forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lab900/forms",
-  "version": "2.2.0-beta.8",
+  "version": "2.2.0-beta.11",
   "author": "Lab900 <info@lab900.com> (https://lab900.com)",
   "licens": "MIT",
   "peerDependencies": {

--- a/projects/forms/package.json
+++ b/projects/forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lab900/forms",
-  "version": "2.1.40",
+  "version": "2.2.0-beta.0",
   "author": "Lab900 <info@lab900.com> (https://lab900.com)",
   "licens": "MIT",
   "peerDependencies": {

--- a/projects/forms/package.json
+++ b/projects/forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lab900/forms",
-  "version": "2.2.0-beta.0",
+  "version": "2.2.0-beta.3",
   "author": "Lab900 <info@lab900.com> (https://lab900.com)",
   "licens": "MIT",
   "peerDependencies": {

--- a/projects/forms/package.json
+++ b/projects/forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lab900/forms",
-  "version": "2.2.0-beta.11",
+  "version": "2.2.0-beta.12",
   "author": "Lab900 <info@lab900.com> (https://lab900.com)",
   "licens": "MIT",
   "peerDependencies": {

--- a/projects/forms/package.json
+++ b/projects/forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lab900/forms",
-  "version": "2.2.0-beta.4",
+  "version": "2.2.0-beta.6",
   "author": "Lab900 <info@lab900.com> (https://lab900.com)",
   "licens": "MIT",
   "peerDependencies": {

--- a/projects/forms/package.json
+++ b/projects/forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lab900/forms",
-  "version": "2.2.0-beta.6",
+  "version": "2.2.0-beta.8",
   "author": "Lab900 <info@lab900.com> (https://lab900.com)",
   "licens": "MIT",
   "peerDependencies": {

--- a/projects/forms/src/assets/i18n.ts
+++ b/projects/forms/src/assets/i18n.ts
@@ -7,6 +7,7 @@ export default {
     'forms.error.min': 'This should be at least {{min}}.',
     'forms.error.max': 'This should be at most {{max}}.',
     'forms.error.generic': 'Field is invalid.',
+    'form.field.loading': 'Loading...',
   },
   nl: {
     'forms.error.number-required': 'Een geldig getal is verplicht.',
@@ -16,5 +17,6 @@ export default {
     'forms.error.min': 'Dit moet minstens {{min}} zijn.',
     'forms.error.max': 'Dit mag maximaal {{max}} zijn.',
     'forms.error.generic': 'Deze waarde is ongeldig.',
+    'form.field.loading': 'Even geduld...',
   },
 };

--- a/projects/forms/src/lib/components/form-container/form-container.component.ts
+++ b/projects/forms/src/lib/components/form-container/form-container.component.ts
@@ -33,21 +33,22 @@ export class FormContainerComponent<T> implements OnChanges {
       this.form = this.fb.createFormGroup(this.schema.fields, null, this.data);
     }
     if (changes.data && this.data) {
-      setTimeout(() => this.patchValues(this.data), 0);
+      setTimeout(() => this.patchValues(this.data, changes.data.previousValue));
     }
   }
 
-  public patchValues(data: T): void {
+  public patchValues(data: T, prevData?: T): void {
     Object.keys(data).forEach((key: string) => {
       const control = this.form.controls[key];
-      if (control) {
+      if (control && data[key] !== prevData?.[key]) {
         if (control instanceof FormArray) {
           const fieldSchema = this.schema.fields.find((field: FormField) => field.attribute === key);
           if (data[key] && fieldSchema) {
             this.fb.createFormArray(data, fieldSchema, control);
           }
+        } else {
+          control.patchValue(data[key]);
         }
-        control.patchValue(data[key]);
       }
     });
   }

--- a/projects/forms/src/lib/components/form-container/form-container.component.ts
+++ b/projects/forms/src/lib/components/form-container/form-container.component.ts
@@ -34,7 +34,7 @@ export class FormContainerComponent<T> implements OnChanges {
       this.form = this.fb.createFormGroup(this.schema.fields, null, this.data);
     }
     if (!changes?.data?.isFirstChange() && this.data) {
-      setTimeout(() => this.patchValues(this.data, changes.data.previousValue));
+      setTimeout(() => this.patchValues(this.data, changes?.data?.previousValue));
     }
   }
 

--- a/projects/forms/src/lib/components/form-container/form-container.component.ts
+++ b/projects/forms/src/lib/components/form-container/form-container.component.ts
@@ -27,6 +27,10 @@ export class FormContainerComponent<T> implements OnChanges {
     return this.form.value as T;
   }
 
+  public get readonly(): boolean {
+    return this.schema?.readonly;
+  }
+
   public constructor(private fb: Lab900FormBuilderService) {}
 
   public ngOnChanges(changes: SimpleChanges): void {

--- a/projects/forms/src/lib/components/form-container/form-container.component.ts
+++ b/projects/forms/src/lib/components/form-container/form-container.component.ts
@@ -3,6 +3,7 @@ import { FormGroup, FormArray } from '@angular/forms';
 import { Form } from '../../models/Form';
 import { Lab900FormBuilderService } from '../../services/form-builder.service';
 import { FormField } from '../../models/FormField';
+import { areValuesEqual } from '../../models/IFieldConditions';
 
 @Component({
   selector: 'lab900-form-container',
@@ -32,7 +33,7 @@ export class FormContainerComponent<T> implements OnChanges {
     if (changes.schema) {
       this.form = this.fb.createFormGroup(this.schema.fields, null, this.data);
     }
-    if (changes.data && this.data) {
+    if (!changes?.data?.isFirstChange() && this.data) {
       setTimeout(() => this.patchValues(this.data, changes.data.previousValue));
     }
   }
@@ -40,7 +41,7 @@ export class FormContainerComponent<T> implements OnChanges {
   public patchValues(data: T, prevData?: T): void {
     Object.keys(data).forEach((key: string) => {
       const control = this.form.controls[key];
-      if (control && data[key] !== prevData?.[key]) {
+      if (control && !areValuesEqual(data[key], prevData?.[key])) {
         if (control instanceof FormArray) {
           const fieldSchema = this.schema.fields.find((field: FormField) => field.attribute === key);
           if (data[key] && fieldSchema) {

--- a/projects/forms/src/lib/components/form-fields/autocomplete-field/autocomplete-field.component.html
+++ b/projects/forms/src/lib/components/form-fields/autocomplete-field/autocomplete-field.component.html
@@ -15,8 +15,9 @@
     <mat-error *ngIf="!valid && !readonly">{{ getErrorMessage() | async }}</mat-error>
     <mat-icon matSuffix *ngIf="!readonly">search</mat-icon>
     <mat-autocomplete #auto="matAutocomplete" [displayWith]="options.displayInputFn">
-        <mat-option *ngFor="let option of filteredOptions | async" [value]="option">
-            <div [innerHTML]="(options.displayOptionFn(option) || option) | translate"></div>
+        <mat-option *ngFor="let option of filteredOptions | async" [value]="option?.value">
+            <div *ngIf="options?.displayOptionFn" [innerHTML]="options.displayOptionFn(option) | translate"></div>
+            <ng-container *ngIf="!options?.displayOptionFn">{{ option.label | translate }}</ng-container>
         </mat-option>
     </mat-autocomplete>
 </mat-form-field>

--- a/projects/forms/src/lib/components/form-fields/autocomplete-field/autocomplete-field.component.html
+++ b/projects/forms/src/lib/components/form-fields/autocomplete-field/autocomplete-field.component.html
@@ -1,19 +1,19 @@
-<mat-form-field [formGroup]="group" *ngIf="!hide(this.group.value)">
+<mat-form-field [formGroup]="group" *ngIf="!fieldIsHidden">
     <mat-label *ngIf="schema.title" translate>{{ schema.title }}</mat-label>
     <input
         #input
         (input)="inputChanged($event)"
         [formControlName]="schema.attribute"
         [matAutocomplete]="auto"
-        [readonly]="isReadonly(this.group.value)"
+        [readonly]="fieldIsReadonly"
         [required]="required"
         matInput
         placeholder="{{ placeholder | translate }}"
         type="text"
     >
-    <mat-hint *ngIf="hint && !readonly && !(schema.options.hint.hideHintOnValidValue && input.value)" translate>{{ hint }}</mat-hint>
-    <mat-error *ngIf="!valid && !readonly">{{ getErrorMessage() | async }}</mat-error>
-    <mat-icon matSuffix *ngIf="!readonly">search</mat-icon>
+    <mat-hint *ngIf="hint && !fieldIsReadonly && !(schema.options.hint.hideHintOnValidValue && input.value)" translate>{{ hint }}</mat-hint>
+    <mat-error *ngIf="!valid && !fieldIsReadonly">{{ getErrorMessage() | async }}</mat-error>
+    <mat-icon matSuffix *ngIf="!fieldIsReadonly">search</mat-icon>
     <mat-autocomplete #auto="matAutocomplete" [displayWith]="options.displayInputFn">
         <mat-option *ngFor="let option of filteredOptions | async" [value]="option?.value">
             <div *ngIf="options?.displayOptionFn" [innerHTML]="options.displayOptionFn(option) | translate"></div>

--- a/projects/forms/src/lib/components/form-fields/autocomplete-field/autocomplete-field.component.ts
+++ b/projects/forms/src/lib/components/form-fields/autocomplete-field/autocomplete-field.component.ts
@@ -19,7 +19,7 @@ export class AutocompleteFieldComponent extends FormComponent<AutocompleteOption
   }
 
   public inputChanged($event: Event) {
-    const res = this.options.getOptionsFn(($event.target as any).value);
+    const res = this.options.autocompleteOptions(($event.target as any).value);
     this.filteredOptions = isObservable(res) ? res : of(res);
   }
 }

--- a/projects/forms/src/lib/components/form-fields/autocomplete-field/autocomplete-field.component.ts
+++ b/projects/forms/src/lib/components/form-fields/autocomplete-field/autocomplete-field.component.ts
@@ -1,6 +1,6 @@
 import { Component, HostBinding } from '@angular/core';
 import { FormComponent } from '../../../models/IFormComponent';
-import { AutocompleteOptions } from '../../../models/FormField';
+import { AutocompleteOptions, ValueLabel } from '../../../models/FormField';
 import { Observable, isObservable, of } from 'rxjs';
 import { TranslateService } from '@ngx-translate/core';
 
@@ -12,7 +12,7 @@ export class AutocompleteFieldComponent extends FormComponent<AutocompleteOption
   @HostBinding('class')
   public classList = 'lab900-form-field';
 
-  public filteredOptions: Observable<any[]>;
+  public filteredOptions: Observable<ValueLabel[]>;
 
   public constructor(translateService: TranslateService) {
     super(translateService);

--- a/projects/forms/src/lib/components/form-fields/autocomplete-multiple-field/autocomplete-multiple-field.component.html
+++ b/projects/forms/src/lib/components/form-fields/autocomplete-multiple-field/autocomplete-multiple-field.component.html
@@ -5,7 +5,7 @@
     <mat-icon matSuffix *ngIf="!readonly">search</mat-icon>
     <mat-chip-list #chipList [formControlName]="schema.attribute">
         <mat-chip *ngFor="let opt of selectedOptions; let i = index" [removable]="!schema.options.readonly" selectable (removed)="remove(i)">
-            <div [innerHTML]="(options.displayOptionFn(opt) || opt) | translate"></div>
+            <div [innerHTML]="options.displayInputFn(opt) | translate"></div>
             <mat-icon *ngIf="!schema.options.readonly" matChipRemove>cancel</mat-icon>
         </mat-chip>
         <input
@@ -20,8 +20,9 @@
         >
     </mat-chip-list>
     <mat-autocomplete #auto="matAutocomplete" (optionSelected)="selected($event)">
-        <mat-option *ngFor="let option of filteredOptions | async" [value]="option">
-            <div [innerHTML]="(options.displayOptionFn(option) || option) | translate"></div>
+        <mat-option *ngFor="let option of filteredOptions | async" [value]="option?.value">
+            <div *ngIf="options?.displayOptionFn" [innerHTML]="options.displayOptionFn(option) | translate"></div>
+            <ng-container *ngIf="!options?.displayOptionFn">{{ option.label | translate }}</ng-container>
         </mat-option>
     </mat-autocomplete>
 </mat-form-field>

--- a/projects/forms/src/lib/components/form-fields/autocomplete-multiple-field/autocomplete-multiple-field.component.html
+++ b/projects/forms/src/lib/components/form-fields/autocomplete-multiple-field/autocomplete-multiple-field.component.html
@@ -1,19 +1,19 @@
-<mat-form-field [formGroup]="group" *ngIf="!hide(this.group.value)">
+<mat-form-field [formGroup]="group" *ngIf="!fieldIsHidden">
     <mat-label *ngIf="schema.title" translate>{{ schema.title }}</mat-label>
-    <mat-hint *ngIf="hint && !readonly && !(schema.options.hint.hideHintOnValidValue && input.value)" translate>{{ hint }}</mat-hint>
-    <mat-error *ngIf="!valid && !readonly">{{ getErrorMessage() | async }}</mat-error>
-    <mat-icon matSuffix *ngIf="!readonly">search</mat-icon>
+    <mat-hint *ngIf="hint && !fieldIsReadonly && !(schema.options.hint.hideHintOnValidValue && input.value)" translate>{{ hint }}</mat-hint>
+    <mat-error *ngIf="!valid && !fieldIsReadonly">{{ getErrorMessage() | async }}</mat-error>
+    <mat-icon matSuffix *ngIf="!fieldIsReadonly">search</mat-icon>
     <mat-chip-list #chipList [formControlName]="schema.attribute">
-        <mat-chip *ngFor="let opt of selectedOptions; let i = index" [removable]="!schema.options.readonly" selectable (removed)="remove(i)">
+        <mat-chip *ngFor="let opt of selectedOptions; let i = index" [removable]="!fieldIsReadonly" selectable (removed)="remove(i)">
             <div [innerHTML]="options.displayInputFn(opt) | translate"></div>
-            <mat-icon *ngIf="!schema.options.readonly" matChipRemove>cancel</mat-icon>
+            <mat-icon *ngIf="!fieldIsReadonly" matChipRemove>cancel</mat-icon>
         </mat-chip>
         <input
             #input
             (input)="inputChanged($event)"
             placeholder="{{ placeholder | translate }}"
             #input
-            [readOnly]="isReadonly(this.group.value)"
+            [readOnly]="fieldIsReadonly"
             [matAutocomplete]="auto"
             [matChipInputFor]="chipList"
             [matChipInputSeparatorKeyCodes]="separatorKeysCodes"

--- a/projects/forms/src/lib/components/form-fields/autocomplete-multiple-field/autocomplete-multiple-field.component.ts
+++ b/projects/forms/src/lib/components/form-fields/autocomplete-multiple-field/autocomplete-multiple-field.component.ts
@@ -31,7 +31,7 @@ export class AutocompleteMultipleFieldComponent extends FormComponent<Autocomple
   }
 
   public inputChanged($event: Event): void {
-    const res = this.options.getOptionsFn(($event.target as any).value);
+    const res = this.options.autocompleteOptions(($event.target as any).value);
     this.filteredOptions = isObservable(res) ? res : of(res);
   }
 

--- a/projects/forms/src/lib/components/form-fields/autocomplete-multiple-field/autocomplete-multiple-field.component.ts
+++ b/projects/forms/src/lib/components/form-fields/autocomplete-multiple-field/autocomplete-multiple-field.component.ts
@@ -1,6 +1,6 @@
 import { Component, ElementRef, HostBinding, ViewChild } from '@angular/core';
 import { FormComponent } from '../../../models/IFormComponent';
-import { AutocompleteOptions } from '../../../models/FormField';
+import { AutocompleteOptions, ValueLabel } from '../../../models/FormField';
 import { isObservable, Observable, of } from 'rxjs';
 import { COMMA, ENTER } from '@angular/cdk/keycodes';
 import { MatAutocomplete, MatAutocompleteSelectedEvent } from '@angular/material/autocomplete';
@@ -19,7 +19,7 @@ export class AutocompleteMultipleFieldComponent extends FormComponent<Autocomple
   @ViewChild('auto')
   private matAutocomplete: MatAutocomplete;
 
-  public filteredOptions: Observable<any[]>;
+  public filteredOptions: Observable<ValueLabel[]>;
   public separatorKeysCodes: number[] = [ENTER, COMMA];
 
   public get selectedOptions(): any[] {

--- a/projects/forms/src/lib/components/form-fields/button-toggle-field/button-toggle-field.component.html
+++ b/projects/forms/src/lib/components/form-fields/button-toggle-field/button-toggle-field.component.html
@@ -1,8 +1,7 @@
 <div [formGroup]="group" *ngIf="!fieldIsHidden" class="button-toggle-field mat-form-field-wrapper">
     <div *ngIf="schema.title"><mat-label>{{ schema.title | translate }}</mat-label></div>
-    <!-- ToDo: Disable when readonly -->
     <mat-button-toggle-group [formControlName]="schema.attribute" [required]="required">
-        <mat-button-toggle *ngFor="let value of options?.buttonOptions" [value]="value.value">
+        <mat-button-toggle [disabled]="fieldIsReadonly" *ngFor="let value of options?.buttonOptions" [value]="value.value">
             <ng-container *ngIf="value.label">
                 {{ value.label | translate }}
             </ng-container>

--- a/projects/forms/src/lib/components/form-fields/button-toggle-field/button-toggle-field.component.html
+++ b/projects/forms/src/lib/components/form-fields/button-toggle-field/button-toggle-field.component.html
@@ -1,4 +1,4 @@
-<div [formGroup]="group" *ngIf="!hide(this.group.value)" class="button-toggle-field mat-form-field-wrapper">
+<div [formGroup]="group" *ngIf="!fieldIsHidden" class="button-toggle-field mat-form-field-wrapper">
     <div *ngIf="schema.title"><mat-label>{{ schema.title | translate }}</mat-label></div>
     <!-- ToDo: Disable when readonly -->
     <mat-button-toggle-group [formControlName]="schema.attribute" [required]="required">
@@ -9,5 +9,5 @@
             <lab900-icon *ngIf="value.icon" [icon]="value.icon"></lab900-icon>
         </mat-button-toggle>
     </mat-button-toggle-group>
-    <mat-error class="mat-form-field-subscript-wrapper" *ngIf="group.controls[schema.attribute].touched && !valid && !readonly">{{ getErrorMessage() | async }}</mat-error>
+    <mat-error class="mat-form-field-subscript-wrapper" *ngIf="group.controls[schema.attribute].touched && !valid && !fieldIsReadonly">{{ getErrorMessage() | async }}</mat-error>
 </div>

--- a/projects/forms/src/lib/components/form-fields/button-toggle-field/button-toggle-field.component.html
+++ b/projects/forms/src/lib/components/form-fields/button-toggle-field/button-toggle-field.component.html
@@ -2,7 +2,7 @@
     <div *ngIf="schema.title"><mat-label>{{ schema.title | translate }}</mat-label></div>
     <!-- ToDo: Disable when readonly -->
     <mat-button-toggle-group [formControlName]="schema.attribute" [required]="required">
-        <mat-button-toggle *ngFor="let value of options?.values" [value]="value.value">
+        <mat-button-toggle *ngFor="let value of options?.buttonOptions" [value]="value.value">
             <ng-container *ngIf="value.label">
                 {{ value.label | translate }}
             </ng-container>

--- a/projects/forms/src/lib/components/form-fields/checkbox-field/checkbox-field.component.html
+++ b/projects/forms/src/lib/components/form-fields/checkbox-field/checkbox-field.component.html
@@ -1,4 +1,4 @@
-<div [formGroup]="group" *ngIf="!hide(this.group.value)">
+<div [formGroup]="group" *ngIf="!fieldIsHidden">
     <!-- ToDo: Disable when readonly -->
     <mat-checkbox
         #checkbox
@@ -9,7 +9,7 @@
     >
       {{schema.title | translate}}
     </mat-checkbox>
-    <div *ngIf="!readonly" class="subscript-wrapper" [@transitionMessages]="valid ? 'void' : 'enter'">
+    <div *ngIf="!fieldIsReadonly" class="subscript-wrapper" [@transitionMessages]="valid ? 'void' : 'enter'">
         <mat-hint *ngIf="hint && !(schema.options.hint.hideHintOnValidValue && checkbox.value)" translate>{{ hint }}</mat-hint>
         <mat-error *ngIf="!valid">{{ getErrorMessage() | async }}</mat-error>
     </div>

--- a/projects/forms/src/lib/components/form-fields/date-field/date-field.component.html
+++ b/projects/forms/src/lib/components/form-fields/date-field/date-field.component.html
@@ -1,4 +1,4 @@
-<mat-form-field [formGroup]="group" *ngIf="!hide(this.group.value)">
+<mat-form-field [formGroup]="group" *ngIf="!fieldIsHidden">
     <mat-label *ngIf="schema.title" translate>{{ schema.title }}</mat-label>
     <input
         #input
@@ -7,12 +7,12 @@
         [matDatepicker]="picker"
         [formControlName]="schema.attribute"
         [required]="required"
-        [readonly]="isReadonly(this.group.value)"
+        [readonly]="fieldIsReadonly"
         [max]="maxDate"
         [min]="minDate"
     >
-    <mat-datepicker-toggle [attr.disabled]="readonly" matSuffix [for]="picker"></mat-datepicker-toggle>
-    <mat-datepicker [disabled]="readonly" #picker [startView]="startView"></mat-datepicker>
-    <mat-hint *ngIf="hint && !readonly  && !(schema.options.hint.hideHintOnValidValue && input.value)" translate>{{ hint }}</mat-hint>
-    <mat-error *ngIf="!valid && !readonly">{{ getErrorMessage() | async }}</mat-error>
+    <mat-datepicker-toggle [attr.disabled]="fieldIsReadonly" matSuffix [for]="picker"></mat-datepicker-toggle>
+    <mat-datepicker [disabled]="fieldIsReadonly" #picker [startView]="startView"></mat-datepicker>
+    <mat-hint *ngIf="hint && !fieldIsReadonly  && !(schema.options.hint.hideHintOnValidValue && input.value)" translate>{{ hint }}</mat-hint>
+    <mat-error *ngIf="!valid && !fieldIsReadonly">{{ getErrorMessage() | async }}</mat-error>
 </mat-form-field>

--- a/projects/forms/src/lib/components/form-fields/date-range-field/date-range-field.component.html
+++ b/projects/forms/src/lib/components/form-fields/date-range-field/date-range-field.component.html
@@ -1,4 +1,4 @@
-<mat-form-field [formGroup]="group" *ngIf="!hide(this.group.value) && dateFormGroup">
+<mat-form-field [formGroup]="group" *ngIf="!fieldIsHidden && dateFormGroup">
     <mat-label *ngIf="schema.title" translate>{{ schema.title }}</mat-label>
     <mat-date-range-input [formGroup]="dateFormGroup" [rangePicker]="picker">
         <input matStartDate [formControl]="dateFormGroup.get(this.options?.startKey || 'start')" placeholder="{{ (this.options?.startLabel || 'Start date') | translate }}">
@@ -6,6 +6,6 @@
     </mat-date-range-input>
     <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
     <mat-date-range-picker #picker></mat-date-range-picker>
-    <mat-hint *ngIf="hint && !readonly  && !(schema.options.hint.hideHintOnValidValue && dateFormGroup.value)" translate>{{ hint }}</mat-hint>
-    <mat-error *ngIf="!valid && !readonly">{{ getErrorMessage() | async }}</mat-error>
+    <mat-hint *ngIf="hint && !fieldIsReadonly  && !(schema.options.hint.hideHintOnValidValue && dateFormGroup.value)" translate>{{ hint }}</mat-hint>
+    <mat-error *ngIf="!valid && !fieldIsReadonly">{{ getErrorMessage() | async }}</mat-error>
 </mat-form-field>

--- a/projects/forms/src/lib/components/form-fields/date-time-field/date-time-field.component.html
+++ b/projects/forms/src/lib/components/form-fields/date-time-field/date-time-field.component.html
@@ -1,4 +1,4 @@
-<mat-form-field [formGroup]="group" *ngIf="!hide(this.group.value)">
+<mat-form-field [formGroup]="group" *ngIf="!fieldIsHidden">
     <mat-label *ngIf="schema.title" translate>{{ schema.title }}</mat-label>
     <input
         #input
@@ -7,14 +7,13 @@
         [ngxMatDatetimePicker]="picker"
         [formControlName]="schema.attribute"
         [required]="required"
-        [readonly]="isReadonly(this.group.value)"
+        [readonly]="fieldIsReadonly"
         [max]="maxDate"
         [min]="minDate"
     >
 
-    <mat-datepicker-toggle [attr.disabled]="readonly" matSuffix [for]="picker"></mat-datepicker-toggle>
-    <ngx-mat-datetime-picker #picker [disabled]="readonly" [showSpinners]="true" [showSeconds]="true" [startView]="startView"></ngx-mat-datetime-picker>
-
-    <mat-hint *ngIf="hint && !readonly  && !(schema.options.hint.hideHintOnValidValue && input.value)" translate>{{ hint }}</mat-hint>
-    <mat-error *ngIf="!valid && !readonly">{{ getErrorMessage() | async }}</mat-error>
+    <mat-datepicker-toggle [attr.disabled]="fieldIsReadonly" matSuffix [for]="picker"></mat-datepicker-toggle>
+    <ngx-mat-datetime-picker #picker [disabled]="fieldIsReadonly" [showSpinners]="true" [showSeconds]="true" [startView]="startView"></ngx-mat-datetime-picker>
+    <mat-hint *ngIf="hint && !fieldIsReadonly  && !(schema.options.hint.hideHintOnValidValue && input.value)" translate>{{ hint }}</mat-hint>
+    <mat-error *ngIf="!valid && !fieldIsReadonly">{{ getErrorMessage() | async }}</mat-error>
 </mat-form-field>

--- a/projects/forms/src/lib/components/form-fields/file-field/file-field.component.html
+++ b/projects/forms/src/lib/components/form-fields/file-field/file-field.component.html
@@ -1,6 +1,6 @@
-<mat-form-field [formGroup]="group" *ngIf="!hide(this.group.value)">
+<mat-form-field [formGroup]="group" *ngIf="!fieldIsHidden">
     <mat-label translate>{{schema.title}}</mat-label>
-    <lab900-mat-file-field [attr.disabled]="readonly" #fileField [formControlName]="schema.attribute"></lab900-mat-file-field>
+    <lab900-mat-file-field [attr.disabled]="fieldIsReadonly" #fileField [formControlName]="schema.attribute"></lab900-mat-file-field>
     <mat-icon matSuffix class="flex">folder</mat-icon>
     <mat-icon *ngIf="!fileField.empty" matSuffix (click)="fileField.clear($event)">close</mat-icon>
     <mat-hint *ngIf="hint" translate>{{ hint }}</mat-hint>

--- a/projects/forms/src/lib/components/form-fields/input-field/input-field.component.html
+++ b/projects/forms/src/lib/components/form-fields/input-field/input-field.component.html
@@ -1,4 +1,4 @@
-<mat-form-field *ngIf="!hide(this.group.value)" [formGroup]="group" class="input-field">
+<mat-form-field *ngIf="!fieldIsHidden" [formGroup]="group" class="input-field">
     <mat-label *ngIf="schema.title">{{ schema.title | translate }}</mat-label>
     <input
         matInput
@@ -7,13 +7,13 @@
         placeholder="{{ placeholder | translate }}"
         [formControlName]="schema.attribute"
         [required]="required"
-        [readonly]="isReadonly(this.group.value)"
-        [ngClass]="{ 'readonly' : (readonly || options?.readonly) }"
+        [readonly]="fieldIsReadonly"
+        [ngClass]="{ 'readonly' : fieldIsReadonly }"
         [mask]="options?.mask"
     >
-    <mat-hint *ngIf="hint && !(schema.options.hint.hideHintOnValidValue && input.value) && !readonly">{{ hint | translate }}</mat-hint>
-    <mat-hint align="end" *ngIf="options?.maxLength && !readonly">{{ input.value?.length || 0 }}/{{ options?.maxLength }}</mat-hint>
-    <mat-error *ngIf="!valid && !readonly">{{ getErrorMessage() | async }}</mat-error>
+    <mat-hint *ngIf="hint && !(schema.options.hint.hideHintOnValidValue && input.value) && !fieldIsReadonly">{{ hint | translate }}</mat-hint>
+    <mat-hint align="end" *ngIf="options?.maxLength && !fieldIsReadonly">{{ input.value?.length || 0 }}/{{ options?.maxLength }}</mat-hint>
+    <mat-error *ngIf="!valid && !fieldIsReadonly">{{ getErrorMessage() | async }}</mat-error>
     <lab900-icon [icon]="schema.icon" *ngIf="schema?.icon?.position === 'left'" matPrefix class="input-field__icon-left"></lab900-icon>
     <lab900-icon [icon]="schema.icon" *ngIf="schema?.icon?.position === 'right'" matSuffix ></lab900-icon>
 </mat-form-field>

--- a/projects/forms/src/lib/components/form-fields/radio-buttons-field/radio-buttons-field.component.html
+++ b/projects/forms/src/lib/components/form-fields/radio-buttons-field/radio-buttons-field.component.html
@@ -1,4 +1,4 @@
-<div [formGroup]="group" *ngIf="!hide(this.group.value)" class="radio-buttons-field">
+<div [formGroup]="group" *ngIf="!fieldIsHidden" class="radio-buttons-field">
     <span *ngIf="schema.title" class="lab900-form-field-label" translate>{{ schema.title }}</span>
     <!-- ToDo: Disable when readonly -->
     <mat-radio-group
@@ -8,7 +8,7 @@
     >
         <mat-radio-button *ngFor="let value of options?.radioOptions" [value]="value.value">{{ value.label | translate }}</mat-radio-button>
     </mat-radio-group>
-    <div class="radio-buttons-field__error" *ngIf="group.controls[schema.attribute].touched && !valid && !readonly">
+    <div class="radio-buttons-field__error" *ngIf="group.controls[schema.attribute].touched && !valid && !fieldIsReadonly">
         <mat-error>{{ getErrorMessage() | async }}</mat-error>
     </div>
 </div>

--- a/projects/forms/src/lib/components/form-fields/radio-buttons-field/radio-buttons-field.component.html
+++ b/projects/forms/src/lib/components/form-fields/radio-buttons-field/radio-buttons-field.component.html
@@ -6,7 +6,7 @@
         [color]="options?.color || 'primary'"
         [required]="required"
     >
-        <mat-radio-button *ngFor="let value of options?.values" [value]="value.value">{{ value.label | translate }}</mat-radio-button>
+        <mat-radio-button *ngFor="let value of options?.radioOptions" [value]="value.value">{{ value.label | translate }}</mat-radio-button>
     </mat-radio-group>
     <div class="radio-buttons-field__error" *ngIf="group.controls[schema.attribute].touched && !valid && !readonly">
         <mat-error>{{ getErrorMessage() | async }}</mat-error>

--- a/projects/forms/src/lib/components/form-fields/range-slider-field/range-slider-field.component.html
+++ b/projects/forms/src/lib/components/form-fields/range-slider-field/range-slider-field.component.html
@@ -1,4 +1,4 @@
-<div [formGroup]="group" *ngIf="!hide(this.group.value)">
+<div [formGroup]="group" *ngIf="!fieldIsHidden">
     <span *ngIf="schema.title" class="lab900-form-field-label" translate>{{ schema.title }}</span>
     <lab900-mat-range-slider-field 
         [formControlName]="schema.attribute" 
@@ -10,7 +10,7 @@
         [format]="options?.format"
         [required]="required"
     ></lab900-mat-range-slider-field>
-    <div class="radio-buttons-field__error" *ngIf="group.controls[schema.attribute].touched && !valid && !readonly">
+    <div class="radio-buttons-field__error" *ngIf="group.controls[schema.attribute].touched && !valid && !fieldIsReadonly">
         <mat-error>{{ getErrorMessage() | async }}</mat-error>
     </div>
 </div>

--- a/projects/forms/src/lib/components/form-fields/readonly-field/readonly-field.component.html
+++ b/projects/forms/src/lib/components/form-fields/readonly-field/readonly-field.component.html
@@ -1,4 +1,4 @@
-<div class="lab900-readonly-field" *ngIf="!hide(this.group.value)">
+<div class="lab900-readonly-field" *ngIf="!fieldIsHidden">
     <span *ngIf="options?.readonlyLabel || schema.title" class="lab900-readonly-field__label">{{ (options?.readonlyLabel || schema.title) | translate }}</span>
     <div [innerHTML]="(value || '-') | translate"></div>
 </div>

--- a/projects/forms/src/lib/components/form-fields/readonly-field/readonly-field.component.html
+++ b/projects/forms/src/lib/components/form-fields/readonly-field/readonly-field.component.html
@@ -1,4 +1,4 @@
-<div class="lab900-readonly-field">
+<div class="lab900-readonly-field" *ngIf="!hide(this.group.value)">
     <span *ngIf="options?.readonlyLabel || schema.title" class="lab900-readonly-field__label">{{ (options?.readonlyLabel || schema.title) | translate }}</span>
     <div [innerHTML]="(value || '-') | translate"></div>
 </div>

--- a/projects/forms/src/lib/components/form-fields/readonly-field/readonly-field.component.scss
+++ b/projects/forms/src/lib/components/form-fields/readonly-field/readonly-field.component.scss
@@ -1,9 +1,0 @@
-.lab900-readonly-field {
-  padding-bottom: 1.34375em;
-
-  &__label {
-    font-weight: bold;
-    margin-bottom: 0.75rem;
-    display: block;
-  }
-}

--- a/projects/forms/src/lib/components/form-fields/readonly-field/readonly-field.component.ts
+++ b/projects/forms/src/lib/components/form-fields/readonly-field/readonly-field.component.ts
@@ -6,7 +6,6 @@ import { TranslateService } from '@ngx-translate/core';
 @Component({
   selector: 'lab900-readonly',
   templateUrl: './readonly-field.component.html',
-  styleUrls: ['./readonly-field.component.scss'],
 })
 export class ReadonlyFieldComponent extends FormComponent implements OnDestroy {
   private sub: Subscription;

--- a/projects/forms/src/lib/components/form-fields/repeater-field/repeater-field.component.html
+++ b/projects/forms/src/lib/components/form-fields/repeater-field/repeater-field.component.html
@@ -1,4 +1,4 @@
-<div [formGroup]="group" *ngIf="!hide(this.group.value)" class="repeater-field" [class.fixed-list]="fixedList">
+<div [formGroup]="group" *ngIf="!fieldIsHidden" class="repeater-field" [class.fixed-list]="fixedList">
     <div [formArrayName]="schema.attribute">
         <span *ngIf="schema.title" class="lab900-form-field-label">{{ schema.title | translate }}</span>
         <div *ngFor="let control of repeaterArray.controls; let i=index" class="repeater-row">
@@ -10,13 +10,13 @@
                     [group]="control"
                 ></ng-container>
             </div>
-            <div *ngIf="!fixedList && !readonly" class="repeater-row__actions">
+            <div *ngIf="!fixedList && !fieldIsReadonly" class="repeater-row__actions">
                 <button *ngIf="(i + 1) > minRows || options?.removeAll" (click)="removeFromArray(i)" mat-mini-fab class="mat-elevation-z0" [color]="options?.buttonColor || 'accent'" aria-label="Delete">
                     <mat-icon>delete</mat-icon>
                 </button>
             </div>
         </div>
-        <div *ngIf="!fixedList && !readonly" class="repeater-field__actions">
+        <div *ngIf="!fixedList && !fieldIsReadonly" class="repeater-field__actions">
             <button mat-button color="primary" [disabled]="!!maxRows && repeaterArray.length >= maxRows" (click)="addToArray()" class="repeater-add">{{ addLabel | translate }}</button>
         </div>
     </div>

--- a/projects/forms/src/lib/components/form-fields/repeater-field/repeater-field.component.ts
+++ b/projects/forms/src/lib/components/form-fields/repeater-field/repeater-field.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, HostBinding } from '@angular/core';
+import { Component, HostBinding, OnInit } from '@angular/core';
 import { FormComponent } from '../../../models/IFormComponent';
 import { FormArray } from '@angular/forms';
 import { RepeaterFieldOptions } from '../../../models/FormField';
@@ -47,12 +47,11 @@ export class RepeaterFieldComponent extends FormComponent<RepeaterFieldOptions> 
   }
 
   public addToArray(): void {
-    /*if (this.schema.nestedFields.length === 1 && !this.schema.nestedFields[0].attribute) {
-      this.schema.nestedFields[0].attribute = this.repeaterArray.length as any;
-      this.repeaterArray.push(new FormControl(''));
-    } else {
-    }*/
-    this.repeaterArray.push(this.fb.createFormGroup(this.schema.nestedFields));
+    const formGroup = this.fb.createFormGroup(this.schema.nestedFields);
+    this.repeaterArray.push(formGroup);
+    if (formGroup.dirty) {
+      this.repeaterArray.markAsDirty();
+    }
   }
 
   public removeFromArray(index: number): void {

--- a/projects/forms/src/lib/components/form-fields/select-field/select-field.component.html
+++ b/projects/forms/src/lib/components/form-fields/select-field/select-field.component.html
@@ -1,19 +1,26 @@
-<ng-container>
-    <mat-form-field [formGroup]="group" *ngIf="!hide(this.group.value)">
-        <mat-label *ngIf="schema.title" translate>{{ schema.title }}</mat-label>
-        <mat-select
-            #select
-            [compareWith]="options?.compareWith ? options?.compareWith : defaultCompare"
-            [formControlName]="schema.attribute"
-            [multiple]="options?.multiple"
-            [required]="required"
-        >
-            <mat-option *ngFor="let item of (options$ | async)" [value]="item.value" translate>
-                <div *ngIf="options?.displayOptionFn" [innerHTML]="options.displayOptionFn(item) | translate"></div>
-                <ng-container *ngIf="!options?.displayOptionFn">{{ item.label | translate }}</ng-container>
-            </mat-option>
-        </mat-select>
-        <mat-hint *ngIf="hint && !readonly && !(schema.options.hint.hideHintOnValidValue && select.value)" translate>{{ hint }}</mat-hint>
-        <mat-error *ngIf="!valid && !readonly">{{ getErrorMessage() | async }}</mat-error>
-    </mat-form-field>
-</ng-container>
+<mat-form-field [formGroup]="group" *ngIf="!readonly && !hide(this.group.value)" [floatLabel]="loading || fieldControl.disabled ? 'never' : 'auto'">
+    <mat-label>
+        <ng-container *ngIf="loading" >{{'form.field.loading' | translate}}</ng-container>
+        <ng-container *ngIf="schema.title && !loading" translate>{{ schema.title }}</ng-container>
+    </mat-label>
+    <mat-select
+        #select
+        [compareWith]="options?.compareWith ? options?.compareWith : defaultCompare"
+        [formControlName]="schema.attribute"
+        [multiple]="options?.multiple"
+        [required]="required"
+    >
+        <mat-option *ngFor="let item of selectOptions" [value]="item.value" translate>
+            <div *ngIf="options?.displayOptionFn" [innerHTML]="options.displayOptionFn(item) | translate"></div>
+            <ng-container *ngIf="!options?.displayOptionFn">{{ item.label | translate }}</ng-container>
+        </mat-option>
+    </mat-select>
+    <mat-hint *ngIf="hint && !readonly && !(schema.options.hint.hideHintOnValidValue && select.value)" translate>{{ hint }}</mat-hint>
+    <mat-error *ngIf="!valid && !readonly">{{ getErrorMessage() | async }}</mat-error>
+</mat-form-field>
+
+<div class="lab900-readonly-field" *ngIf="readonly && !hide(this.group.value)">
+    <span *ngIf="options?.readonlyLabel || schema.title" class="lab900-readonly-field__label">{{ (options?.readonlyLabel || schema.title) | translate }}</span>
+    <div  *ngIf="!loading || !fieldControl.value">{{ this.selectedOption?.label || '-' | translate }}</div>
+    <div *ngIf="loading && fieldControl.value" >{{'form.field.loading' | translate}}</div>
+</div>

--- a/projects/forms/src/lib/components/form-fields/select-field/select-field.component.html
+++ b/projects/forms/src/lib/components/form-fields/select-field/select-field.component.html
@@ -1,4 +1,4 @@
-<mat-form-field [formGroup]="group" *ngIf="!readonly && !hide(group.value)" [floatLabel]="loading || fieldControl.disabled ? 'never' : 'auto'">
+<mat-form-field [formGroup]="group" *ngIf="!isReadonly() && !hide(group.value)" [floatLabel]="loading || fieldControl.disabled ? 'never' : 'auto'">
     <mat-label>
         <ng-container *ngIf="loading" >{{'form.field.loading' | translate}}</ng-container>
         <ng-container *ngIf="schema.title && !loading" translate>{{ schema.title }}</ng-container>
@@ -19,7 +19,7 @@
     <mat-error *ngIf="!valid && !readonly">{{ getErrorMessage() | async }}</mat-error>
 </mat-form-field>
 
-<div class="lab900-readonly-field" *ngIf="readonly && !hide(group.value)">
+<div class="lab900-readonly-field" *ngIf="isReadonly() && !hide(group.value)">
     <span *ngIf="options?.readonlyLabel || schema.title" class="lab900-readonly-field__label">{{ (options?.readonlyLabel || schema.title) | translate }}</span>
     <div  *ngIf="!loading || !fieldControl.value">{{ selectedOption?.label || '-' | translate }}</div>
     <div *ngIf="loading && fieldControl.value" >{{'form.field.loading' | translate}}</div>

--- a/projects/forms/src/lib/components/form-fields/select-field/select-field.component.html
+++ b/projects/forms/src/lib/components/form-fields/select-field/select-field.component.html
@@ -1,7 +1,7 @@
-<mat-form-field [formGroup]="group" *ngIf="!isReadonly(group.value) && !hide(group.value)" [floatLabel]="loading || fieldControl.disabled ? 'never' : 'auto'">
+<mat-form-field [formGroup]="group" *ngIf="!fieldIsReadonly && !fieldIsHidden" [floatLabel]="loading || fieldControl.disabled ? 'never' : 'auto'">
     <mat-label>
         <ng-container *ngIf="loading" >{{'form.field.loading' | translate}}</ng-container>
-        <ng-container *ngIf="schema.title && !loading" translate>{{ schema.title }}</ng-container>
+        <ng-container *ngIf="schema.title && !loading">{{ schema.title | translate }}</ng-container>
     </mat-label>
     <mat-select
         #select
@@ -10,16 +10,16 @@
         [multiple]="options?.multiple"
         [required]="required"
     >
-        <mat-option *ngFor="let item of selectOptions" [value]="item.value" translate>
+        <mat-option *ngFor="let item of selectOptions" [value]="item.value">
             <div *ngIf="options?.displayOptionFn" [innerHTML]="options.displayOptionFn(item) | translate"></div>
             <ng-container *ngIf="!options?.displayOptionFn">{{ item.label | translate }}</ng-container>
         </mat-option>
     </mat-select>
-    <mat-hint *ngIf="hint && !readonly && !(schema.options.hint.hideHintOnValidValue && select.value)" translate>{{ hint }}</mat-hint>
-    <mat-error *ngIf="!valid && !readonly">{{ getErrorMessage() | async }}</mat-error>
+    <mat-hint *ngIf="hint && !(schema.options.hint.hideHintOnValidValue && select.value)">{{ hint | translate }}</mat-hint>
+    <mat-error *ngIf="!valid">{{ getErrorMessage() | async }}</mat-error>
 </mat-form-field>
 
-<div class="lab900-readonly-field" *ngIf="isReadonly(group.value) && !hide(group.value)">
+<div class="lab900-readonly-field" *ngIf="fieldIsReadonly && !fieldIsHidden">
     <span *ngIf="options?.readonlyLabel || schema.title" class="lab900-readonly-field__label">{{ (options?.readonlyLabel || schema.title) | translate }}</span>
     <div  *ngIf="!loading || !fieldControl.value">{{ selectedOption?.label || '-' | translate }}</div>
     <div *ngIf="loading && fieldControl.value" >{{'form.field.loading' | translate}}</div>

--- a/projects/forms/src/lib/components/form-fields/select-field/select-field.component.html
+++ b/projects/forms/src/lib/components/form-fields/select-field/select-field.component.html
@@ -1,17 +1,19 @@
-<mat-form-field [formGroup]="group" *ngIf="!hide(this.group.value)">
-    <mat-label *ngIf="schema.title" translate>{{ schema.title }}</mat-label>
-    <mat-select
-        #select
-        [compareWith]="options?.compareWith || defaultCompare"
-        [formControlName]="schema.attribute"
-        [multiple]="options?.multiple"
-        [required]="required"
-    >
-        <mat-option *ngFor="let item of (options$ | async)" [value]="item.value" translate>
-            <div *ngIf="options?.displayOptionFn" [innerHTML]="options.displayOptionFn(item) | translate"></div>
-            <ng-container *ngIf="!options?.displayOptionFn">{{ item.label | translate }}</ng-container>
-        </mat-option>
-    </mat-select>
-    <mat-hint *ngIf="hint && !readonly && !(schema.options.hint.hideHintOnValidValue && select.value)" translate>{{ hint }}</mat-hint>
-    <mat-error *ngIf="!valid && !readonly">{{ getErrorMessage() | async }}</mat-error>
-</mat-form-field>
+<ng-container>
+    <mat-form-field [formGroup]="group" *ngIf="!hide(this.group.value)">
+        <mat-label *ngIf="schema.title" translate>{{ schema.title }}</mat-label>
+        <mat-select
+            #select
+            [compareWith]="options?.compareWith ? options?.compareWith : defaultCompare"
+            [formControlName]="schema.attribute"
+            [multiple]="options?.multiple"
+            [required]="required"
+        >
+            <mat-option *ngFor="let item of (options$ | async)" [value]="item.value" translate>
+                <div *ngIf="options?.displayOptionFn" [innerHTML]="options.displayOptionFn(item) | translate"></div>
+                <ng-container *ngIf="!options?.displayOptionFn">{{ item.label | translate }}</ng-container>
+            </mat-option>
+        </mat-select>
+        <mat-hint *ngIf="hint && !readonly && !(schema.options.hint.hideHintOnValidValue && select.value)" translate>{{ hint }}</mat-hint>
+        <mat-error *ngIf="!valid && !readonly">{{ getErrorMessage() | async }}</mat-error>
+    </mat-form-field>
+</ng-container>

--- a/projects/forms/src/lib/components/form-fields/select-field/select-field.component.html
+++ b/projects/forms/src/lib/components/form-fields/select-field/select-field.component.html
@@ -1,4 +1,4 @@
-<mat-form-field [formGroup]="group" *ngIf="!readonly && !hide(this.group.value)" [floatLabel]="loading || fieldControl.disabled ? 'never' : 'auto'">
+<mat-form-field [formGroup]="group" *ngIf="!readonly && !hide(group.value)" [floatLabel]="loading || fieldControl.disabled ? 'never' : 'auto'">
     <mat-label>
         <ng-container *ngIf="loading" >{{'form.field.loading' | translate}}</ng-container>
         <ng-container *ngIf="schema.title && !loading" translate>{{ schema.title }}</ng-container>
@@ -19,8 +19,8 @@
     <mat-error *ngIf="!valid && !readonly">{{ getErrorMessage() | async }}</mat-error>
 </mat-form-field>
 
-<div class="lab900-readonly-field" *ngIf="readonly && !hide(this.group.value)">
+<div class="lab900-readonly-field" *ngIf="readonly && !hide(group.value)">
     <span *ngIf="options?.readonlyLabel || schema.title" class="lab900-readonly-field__label">{{ (options?.readonlyLabel || schema.title) | translate }}</span>
-    <div  *ngIf="!loading || !fieldControl.value">{{ this.selectedOption?.label || '-' | translate }}</div>
+    <div  *ngIf="!loading || !fieldControl.value">{{ selectedOption?.label || '-' | translate }}</div>
     <div *ngIf="loading && fieldControl.value" >{{'form.field.loading' | translate}}</div>
 </div>

--- a/projects/forms/src/lib/components/form-fields/select-field/select-field.component.html
+++ b/projects/forms/src/lib/components/form-fields/select-field/select-field.component.html
@@ -7,7 +7,7 @@
         [multiple]="options?.multiple"
         [required]="required"
     >
-        <mat-option *ngFor="let item of values" [value]="item.value" translate>
+        <mat-option *ngFor="let item of (options$ | async)" [value]="item.value" translate>
             <div *ngIf="options?.displayOptionFn" [innerHTML]="options.displayOptionFn(item) | translate"></div>
             <ng-container *ngIf="!options?.displayOptionFn">{{ item.label | translate }}</ng-container>
         </mat-option>

--- a/projects/forms/src/lib/components/form-fields/select-field/select-field.component.html
+++ b/projects/forms/src/lib/components/form-fields/select-field/select-field.component.html
@@ -1,4 +1,4 @@
-<mat-form-field [formGroup]="group" *ngIf="!isReadonly() && !hide(group.value)" [floatLabel]="loading || fieldControl.disabled ? 'never' : 'auto'">
+<mat-form-field [formGroup]="group" *ngIf="!isReadonly(group.value) && !hide(group.value)" [floatLabel]="loading || fieldControl.disabled ? 'never' : 'auto'">
     <mat-label>
         <ng-container *ngIf="loading" >{{'form.field.loading' | translate}}</ng-container>
         <ng-container *ngIf="schema.title && !loading" translate>{{ schema.title }}</ng-container>
@@ -19,7 +19,7 @@
     <mat-error *ngIf="!valid && !readonly">{{ getErrorMessage() | async }}</mat-error>
 </mat-form-field>
 
-<div class="lab900-readonly-field" *ngIf="isReadonly() && !hide(group.value)">
+<div class="lab900-readonly-field" *ngIf="isReadonly(group.value) && !hide(group.value)">
     <span *ngIf="options?.readonlyLabel || schema.title" class="lab900-readonly-field__label">{{ (options?.readonlyLabel || schema.title) | translate }}</span>
     <div  *ngIf="!loading || !fieldControl.value">{{ selectedOption?.label || '-' | translate }}</div>
     <div *ngIf="loading && fieldControl.value" >{{'form.field.loading' | translate}}</div>

--- a/projects/forms/src/lib/components/form-fields/select-field/select-field.component.ts
+++ b/projects/forms/src/lib/components/form-fields/select-field/select-field.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, HostBinding } from '@angular/core';
+import { Component, HostBinding, OnInit } from '@angular/core';
 import { FormComponent } from '../../../models/IFormComponent';
 import { SelectFieldOptions, ValueLabel } from '../../../models/FormField';
 import { TranslateService } from '@ngx-translate/core';
@@ -11,17 +11,6 @@ import { IFieldConditions } from '../../../models/IFieldConditions';
   templateUrl: './select-field.component.html',
 })
 export class SelectFieldComponent extends FormComponent<SelectFieldOptions> implements OnInit {
-  private conditionalChange = new Subject();
-
-  @HostBinding('class')
-  public classList = 'lab900-form-field';
-
-  public selectOptions: ValueLabel[];
-
-  public loading = true;
-
-  public defaultCompare = (o1: any, o2: any) => o1 === o2;
-
   public constructor(translateService: TranslateService) {
     super(translateService);
     this.subs.push(
@@ -30,6 +19,9 @@ export class SelectFieldComponent extends FormComponent<SelectFieldOptions> impl
         .subscribe((options: ValueLabel[]) => {
           this.selectOptions = options;
           this.loading = false;
+          if (this.valueBeforeConditionalChange) {
+            this.fieldControl.setValue(this.valueBeforeConditionalChange);
+          }
         }),
     );
   }
@@ -40,6 +32,18 @@ export class SelectFieldComponent extends FormComponent<SelectFieldOptions> impl
     }
     return null;
   }
+  private conditionalChange = new Subject();
+
+  @HostBinding('class')
+  public classList = 'lab900-form-field';
+
+  public selectOptions: ValueLabel[];
+
+  public loading = true;
+
+  private valueBeforeConditionalChange: any;
+
+  public defaultCompare = (o1: any, o2: any) => o1 === o2;
 
   public ngOnInit(): void {
     if (this.options?.selectOptions) {
@@ -58,6 +62,7 @@ export class SelectFieldComponent extends FormComponent<SelectFieldOptions> impl
   public onConditionalChange(dependOn: string, value: string): void {
     const condition = this.schema.conditions.find((c) => c.dependOn === dependOn);
     if (condition?.conditionalOptions) {
+      this.valueBeforeConditionalChange = this.fieldControl.value;
       this.fieldControl.reset();
       this.conditionalChange.next({ condition, value });
     } else {

--- a/projects/forms/src/lib/components/form-fields/select-field/select-field.component.ts
+++ b/projects/forms/src/lib/components/form-fields/select-field/select-field.component.ts
@@ -3,7 +3,7 @@ import { FormComponent } from '../../../models/IFormComponent';
 import { SelectFieldOptions, ValueLabel } from '../../../models/FormField';
 import { TranslateService } from '@ngx-translate/core';
 import { isObservable, Observable, of, Subject } from 'rxjs';
-import { catchError, switchMap, take } from 'rxjs/operators';
+import { catchError, switchMap, take, tap } from 'rxjs/operators';
 import { IFieldConditions } from '../../../models/IFieldConditions';
 
 @Component({
@@ -22,7 +22,11 @@ export class SelectFieldComponent extends FormComponent<SelectFieldOptions> impl
 
   public get selectedOption(): any {
     if (this.selectOptions && this.fieldControl.value) {
-      return this.selectOptions.find((opt) => this.defaultCompare(opt.value, this.fieldControl.value));
+      return this.selectOptions.find((opt) =>
+        this.options?.compareWith
+          ? this.options?.compareWith(opt.value, this.fieldControl.value)
+          : this.defaultCompare(opt.value, this.fieldControl.value),
+      );
     }
     return null;
   }
@@ -31,7 +35,10 @@ export class SelectFieldComponent extends FormComponent<SelectFieldOptions> impl
     super(translateService);
     this.subs.push(
       this.conditionalChange
-        .pipe(switchMap(({ condition, value }) => this.getConditionalOptions(condition, value)))
+        .pipe(
+          tap(console.log),
+          switchMap(({ condition, value }) => this.getConditionalOptions(condition, value)),
+        )
         .subscribe((options: ValueLabel[]) => {
           this.selectOptions = options;
           this.loading = false;

--- a/projects/forms/src/lib/components/form-fields/select-field/select-field.component.ts
+++ b/projects/forms/src/lib/components/form-fields/select-field/select-field.component.ts
@@ -1,39 +1,32 @@
-import { Component, OnInit, HostBinding, OnDestroy } from '@angular/core';
+import { Component, OnInit, HostBinding } from '@angular/core';
 import { FormComponent } from '../../../models/IFormComponent';
-import { SelectFieldOptions } from '../../../models/FormField';
+import { SelectFieldOptions, ValueLabel } from '../../../models/FormField';
 import { TranslateService } from '@ngx-translate/core';
-import { Subscription } from 'rxjs';
+import { isObservable, Observable, of } from 'rxjs';
 
 @Component({
   selector: 'lab900-select-field',
   templateUrl: './select-field.component.html',
 })
-export class SelectFieldComponent extends FormComponent<SelectFieldOptions> implements OnInit, OnDestroy {
+export class SelectFieldComponent extends FormComponent<SelectFieldOptions> implements OnInit {
   @HostBinding('class')
   public classList = 'lab900-form-field';
 
-  public values: { value: any; label: string }[];
+  public options$: Observable<ValueLabel[]>;
 
-  private subscriptions: Subscription[] = [];
-
-  public defaultCompare = (o1: any, o2: any) => o1 === o2;
+  public defaultCompare = (o1: ValueLabel, o2: ValueLabel) => o1?.value === o2?.value;
 
   public constructor(translateService: TranslateService) {
     super(translateService);
   }
 
   public ngOnInit(): void {
-    this.values = (this.options && this.options.values) || [];
-    if (this.options.valuesFn) {
-      this.loadValues();
+    if (this.options?.selectOptions) {
+      const options = this.options?.selectOptions;
+      const values = typeof options === 'function' ? options() : options;
+      this.options$ = isObservable(values) ? values : of(values);
+    } else {
+      throw new Error('No options provided');
     }
-  }
-
-  public loadValues() {
-    this.subscriptions.push(this.options.valuesFn().subscribe((values) => (this.values = values)));
-  }
-
-  public ngOnDestroy(): void {
-    this.subscriptions.forEach((value) => value.unsubscribe());
   }
 }

--- a/projects/forms/src/lib/components/form-fields/select-field/select-field.component.ts
+++ b/projects/forms/src/lib/components/form-fields/select-field/select-field.component.ts
@@ -67,20 +67,24 @@ export class SelectFieldComponent extends FormComponent<SelectFieldOptions> impl
     }
   }
 
-  public onConditionalChange(dependOn: string, value: string): void {
-    const condition = this.schema.conditions.find((c) => c.dependOn === dependOn);
-    if (condition?.conditionalOptions) {
-      this.fieldControl.reset();
-      this.conditionalChange.next({ condition, value });
-    } else {
-      this.selectOptions = [];
-    }
+  public onConditionalChange(dependOn: string, value: string, firstRun: boolean): void {
+    setTimeout(() => {
+      const condition = this.schema.conditions.find((c) => c.dependOn === dependOn);
+      if (condition?.conditionalOptions) {
+        if (!firstRun || !value) {
+          this.fieldControl.reset();
+        }
+        this.conditionalChange.next({ condition, value });
+      } else {
+        this.selectOptions = [];
+      }
+    });
   }
 
   private getConditionalOptions(condition: IFieldConditions, value: any): Observable<ValueLabel[]> {
     this.selectOptions = [];
     this.loading = true;
-    const values = condition?.conditionalOptions(value);
+    const values = condition?.conditionalOptions(value, this.fieldControl);
     return (isObservable(values) ? values : of(values)).pipe(catchError(() => of([])));
   }
 }

--- a/projects/forms/src/lib/components/form-fields/select-field/select-field.component.ts
+++ b/projects/forms/src/lib/components/form-fields/select-field/select-field.component.ts
@@ -3,7 +3,7 @@ import { FormComponent } from '../../../models/IFormComponent';
 import { SelectFieldOptions, ValueLabel } from '../../../models/FormField';
 import { TranslateService } from '@ngx-translate/core';
 import { isObservable, Observable, of, Subject } from 'rxjs';
-import { catchError, switchMap, take, tap } from 'rxjs/operators';
+import { catchError, switchMap, take } from 'rxjs/operators';
 import { IFieldConditions } from '../../../models/IFieldConditions';
 
 @Component({

--- a/projects/forms/src/lib/components/form-fields/select-field/select-field.component.ts
+++ b/projects/forms/src/lib/components/form-fields/select-field/select-field.component.ts
@@ -35,10 +35,7 @@ export class SelectFieldComponent extends FormComponent<SelectFieldOptions> impl
     super(translateService);
     this.subs.push(
       this.conditionalChange
-        .pipe(
-          tap(console.log),
-          switchMap(({ condition, value }) => this.getConditionalOptions(condition, value)),
-        )
+        .pipe(switchMap(({ condition, value }) => this.getConditionalOptions(condition, value)))
         .subscribe((options: ValueLabel[]) => {
           this.selectOptions = options;
           this.loading = false;

--- a/projects/forms/src/lib/components/form-fields/select-field/select-field.component.ts
+++ b/projects/forms/src/lib/components/form-fields/select-field/select-field.component.ts
@@ -14,7 +14,7 @@ export class SelectFieldComponent extends FormComponent<SelectFieldOptions> impl
 
   public options$: Observable<ValueLabel[]>;
 
-  public defaultCompare = (o1: ValueLabel, o2: ValueLabel) => o1?.value === o2?.value;
+  public defaultCompare = (o1: any, o2: any) => o1 === o2;
 
   public constructor(translateService: TranslateService) {
     super(translateService);

--- a/projects/forms/src/lib/components/form-fields/textarea-field/textarea-field.component.html
+++ b/projects/forms/src/lib/components/form-fields/textarea-field/textarea-field.component.html
@@ -1,16 +1,16 @@
-<mat-form-field *ngIf="!hide(this.group.value)" [formGroup]="group">
+<mat-form-field *ngIf="!fieldIsHidden" [formGroup]="group">
     <mat-label *ngIf="schema.title" translate>{{ schema.title }}</mat-label>
     <textarea
         #input
-        [readonly]="isReadonly(this.group.value)"
+        [readonly]="fieldIsReadonly"
         [formControlName]="schema.attribute"
         [required]="required"
         matInput
         placeholder="{{ placeholder | translate }}"
     ></textarea>
-    <mat-hint *ngIf="hint && !readonly && !(schema.options.hint.hideHintOnValidValue && input.value)" translate>{{ hint }}</mat-hint>
-    <mat-hint *ngIf="options?.maxLength && !readonly" align="end">
+    <mat-hint *ngIf="hint && !fieldIsReadonly && !(schema.options.hint.hideHintOnValidValue && input.value)" translate>{{ hint }}</mat-hint>
+    <mat-hint *ngIf="options?.maxLength && !fieldIsReadonly" align="end">
         {{ input.value?.length || 0 }}/{{ options?.maxLength }}
     </mat-hint>
-    <mat-error *ngIf="!valid && !readonly">{{ getErrorMessage() | async }}</mat-error>
+    <mat-error *ngIf="!valid && !fieldIsReadonly">{{ getErrorMessage() | async }}</mat-error>
 </mat-form-field>

--- a/projects/forms/src/lib/components/form-row/form-row.component.html
+++ b/projects/forms/src/lib/components/form-row/form-row.component.html
@@ -1,5 +1,5 @@
 <ng-container *ngIf="visible">
-    <span *ngIf="(readonly && options?.readonlyLabel) || schema.title" class="lab900-form-field-label">{{ (!readonly ? schema.title : (options?.readonlyLabel || schema.title)) | translate }}</span>
+    <span *ngIf="(fieldIsReadonly && options?.readonlyLabel) || schema.title" class="lab900-form-field-label">{{ (!readonly ? schema.title : (options?.readonlyLabel || schema.title)) | translate }}</span>
     <div class="form-row">
         <div
             *ngFor="let field of schema.nestedFields;"
@@ -10,7 +10,7 @@
                 lab900FormField
                 [schema]="field"
                 [group]="schema.attribute ? group.get(schema.attribute) : group"
-                [readonly]="readonly"
+                [readonly]="fieldIsReadonly"
             ></ng-container>
         </div>
     </div>

--- a/projects/forms/src/lib/components/form-row/form-row.component.html
+++ b/projects/forms/src/lib/components/form-row/form-row.component.html
@@ -1,5 +1,5 @@
 <ng-container *ngIf="visible">
-    <span *ngIf="(fieldIsReadonly && options?.readonlyLabel) || schema.title" class="lab900-form-field-label">{{ (!readonly ? schema.title : (options?.readonlyLabel || schema.title)) | translate }}</span>
+    <span *ngIf="(fieldIsReadonly && options?.readonlyLabel) || schema.title" class="lab900-form-field-label">{{ (!fieldIsReadonly ? schema.title : (options?.readonlyLabel || schema.title)) | translate }}</span>
     <div class="form-row">
         <div
             *ngFor="let field of schema.nestedFields;"

--- a/projects/forms/src/lib/directives/form-field.directive.ts
+++ b/projects/forms/src/lib/directives/form-field.directive.ts
@@ -105,8 +105,10 @@ export class FormFieldDirective implements IFormComponent<FieldOptions>, OnChang
 
   public ngOnInit(): void {
     this.validateType();
-
-    const c = this.readonly && this.schema.editType !== EditType.Row ? ReadonlyFieldComponent : mapToComponent(this.schema);
+    const c =
+      this.readonly && ![EditType.Row, EditType.Select].includes(this.schema.editType)
+        ? ReadonlyFieldComponent
+        : mapToComponent(this.schema);
     const component = this.resolver.resolveComponentFactory<FormComponent<FieldOptions>>(c);
     this.component = this.container.createComponent(component);
     this.component.instance.schema = this.schema;

--- a/projects/forms/src/lib/directives/form-field.directive.ts
+++ b/projects/forms/src/lib/directives/form-field.directive.ts
@@ -6,6 +6,7 @@ import {
   OnChanges,
   OnDestroy,
   OnInit,
+  SimpleChanges,
   Type,
   ViewContainerRef,
 } from '@angular/core';
@@ -95,31 +96,42 @@ export class FormFieldDirective implements IFormComponent<FieldOptions>, OnChang
 
   public constructor(private resolver: ComponentFactoryResolver, private container: ViewContainerRef) {}
 
-  public ngOnChanges(): void {
+  public ngOnChanges(changes: SimpleChanges): void {
     if (this.component) {
-      this.component.instance.schema = this.schema;
-      this.component.instance.group = this.group;
-      this.component.instance.readonly = this.readonly;
+      if (changes.readonly && !changes.readonly?.firstChange && changes.readonly?.previousValue !== this.readonly) {
+        this.createComponent();
+      } else {
+        this.setComponentProps();
+      }
     }
   }
 
   public ngOnInit(): void {
     this.validateType();
-    const c =
-      this.readonly && ![EditType.Row, EditType.Select].includes(this.schema.editType)
-        ? ReadonlyFieldComponent
-        : mapToComponent(this.schema);
-    const component = this.resolver.resolveComponentFactory<FormComponent<FieldOptions>>(c);
-    this.component = this.container.createComponent(component);
-    this.component.instance.schema = this.schema;
-    this.component.instance.group = this.group;
-    this.component.instance.readonly = this.readonly;
+    this.createComponent();
   }
 
   public ngOnDestroy(): void {
     if (this.statusChangeSubscription) {
       this.statusChangeSubscription.unsubscribe();
     }
+  }
+
+  private createComponent(): void {
+    this.container.clear();
+    const c =
+      this.readonly && ![EditType.Row, EditType.Select].includes(this.schema.editType)
+        ? ReadonlyFieldComponent
+        : mapToComponent(this.schema);
+    const component = this.resolver.resolveComponentFactory<FormComponent<FieldOptions>>(c);
+    this.component = this.container.createComponent(component);
+    this.setComponentProps();
+  }
+
+  private setComponentProps(): void {
+    this.component.instance.schema = this.schema;
+    this.component.instance.group = this.group;
+    this.component.instance.readonly = this.readonly;
   }
 
   private validateType() {

--- a/projects/forms/src/lib/forms.module.ts
+++ b/projects/forms/src/lib/forms.module.ts
@@ -49,6 +49,7 @@ import { ReadonlyFieldComponent } from './components/form-fields/readonly-field/
 import { DateRangeFieldComponent } from './components/form-fields/date-range-field/date-range-field.component';
 import { NgxMatDatetimePickerModule, NgxMatNativeDateModule, NgxMatTimepickerModule } from '@angular-material-components/datetime-picker';
 import { DateTimeFieldComponent } from './components/form-fields/date-time-field/date-time-field.component';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 
 const customFields = [
   UnknownFieldComponent,
@@ -109,6 +110,7 @@ const customFields = [
     NgxMatNativeDateModule,
     NgxMatDatetimePickerModule,
     NgxMatTimepickerModule,
+    MatProgressSpinnerModule,
   ],
   exports: [FormContainerComponent, FormDialogDirective],
 })

--- a/projects/forms/src/lib/models/FormField.ts
+++ b/projects/forms/src/lib/models/FormField.ts
@@ -57,6 +57,7 @@ export interface RepeaterFieldOptions extends FieldOptions {
 export interface SelectFieldOptions extends FieldOptions {
   multiple?: boolean;
   selectOptions?: (() => ValueLabel[] | Observable<ValueLabel[]>) | ValueLabel[] | Observable<ValueLabel[]>;
+  conditionalSelectOptions?: (dependOn: string, value: string) => ValueLabel[] | Observable<ValueLabel[]>;
   compareWith?: (o1: any, o2: any) => boolean;
   displayOptionFn?: (option: any) => string;
 }

--- a/projects/forms/src/lib/models/FormField.ts
+++ b/projects/forms/src/lib/models/FormField.ts
@@ -57,15 +57,15 @@ export interface RepeaterFieldOptions extends FieldOptions {
 export interface SelectFieldOptions extends FieldOptions {
   multiple?: boolean;
   selectOptions?: (() => ValueLabel[] | Observable<ValueLabel[]>) | ValueLabel[] | Observable<ValueLabel[]>;
-  conditionalSelectOptions?: (dependOn: string, value: string) => ValueLabel[] | Observable<ValueLabel[]>;
+  conditionalSelectOptions?: (dependOn: string, value: any) => ValueLabel[] | Observable<ValueLabel[]>;
   compareWith?: (o1: any, o2: any) => boolean;
-  displayOptionFn?: (option: any) => string;
+  displayOptionFn?: (option: ValueLabel) => string;
 }
 
 export interface AutocompleteOptions extends FieldOptions {
-  displayInputFn: (option: any) => string;
-  displayOptionFn: (option: any) => string;
-  autocompleteOptions?: (searchTerm: string) => any[] | Observable<any[]>;
+  displayInputFn: (option: any) => string; // the value of the ValueLabel will be passed here
+  displayOptionFn: (option: ValueLabel) => string;
+  autocompleteOptions?: (searchTerm: string) => ValueLabel[] | Observable<ValueLabel[]>;
 }
 
 export interface RadioButtonsFieldOptions extends FieldOptions {

--- a/projects/forms/src/lib/models/FormField.ts
+++ b/projects/forms/src/lib/models/FormField.ts
@@ -4,6 +4,11 @@ import { ThemePalette } from '@angular/material/core';
 import { Observable } from 'rxjs';
 import { IFormComponent } from './IFormComponent';
 
+export interface ValueLabel<T = any> {
+  value: T;
+  label: string;
+}
+
 export interface FieldOptions {
   hide?: boolean | ((data?: any) => boolean);
   hint?: { value: string; hideHintOnValidValue?: boolean };
@@ -49,20 +54,19 @@ export interface RepeaterFieldOptions extends FieldOptions {
 
 export interface SelectFieldOptions extends FieldOptions {
   multiple?: boolean;
-  values?: { value: any; label: string }[];
-  valuesFn?: () => Observable<{ value: any; label: string }[]>;
-  compareWith?: (o1: any, o2: any) => boolean;
-  displayOptionFn?: (option: { value: any; label: string }) => string;
+  selectOptions?: (() => ValueLabel[] | Observable<ValueLabel[]>) | ValueLabel[] | Observable<ValueLabel[]>;
+  compareWith?: (o1: ValueLabel, o2: ValueLabel) => boolean;
+  displayOptionFn?: (option: any) => string;
 }
 
 export interface AutocompleteOptions extends FieldOptions {
   displayInputFn: (option: any) => string;
   displayOptionFn: (option: any) => string;
-  getOptionsFn: (searchTerm: string) => any[] | Observable<any[]>;
+  autocompleteOptions?: (searchTerm: string) => any[] | Observable<any[]>;
 }
 
 export interface RadioButtonsFieldOptions extends FieldOptions {
-  values: { value: any; label: string }[];
+  radioOptions: ValueLabel[];
 }
 
 export interface DatepickerFieldOptions extends FieldOptions {
@@ -91,7 +95,7 @@ export interface IconFieldOptions extends FieldOptions {
   icon?: Icon;
 }
 export interface ButtonToggleFieldOptions extends FieldOptions {
-  values: { value: any; label?: string; icon?: Icon }[];
+  buttonOptions: { value: any; label?: string; icon?: Icon }[];
 }
 export interface Icon {
   name?: string;

--- a/projects/forms/src/lib/models/FormField.ts
+++ b/projects/forms/src/lib/models/FormField.ts
@@ -3,6 +3,8 @@ import { AngularEditorConfig } from '@kolkov/angular-editor';
 import { ThemePalette } from '@angular/material/core';
 import { Observable } from 'rxjs';
 import { IFormComponent } from './IFormComponent';
+import { AbstractControl, FormControl } from '@angular/forms';
+import { IFieldConditions } from './IFieldConditions';
 
 export interface ValueLabel<T = any> {
   value: T;
@@ -55,7 +57,7 @@ export interface RepeaterFieldOptions extends FieldOptions {
 export interface SelectFieldOptions extends FieldOptions {
   multiple?: boolean;
   selectOptions?: (() => ValueLabel[] | Observable<ValueLabel[]>) | ValueLabel[] | Observable<ValueLabel[]>;
-  compareWith?: (o1: ValueLabel, o2: ValueLabel) => boolean;
+  compareWith?: (o1: any, o2: any) => boolean;
   displayOptionFn?: (option: any) => string;
 }
 
@@ -123,4 +125,5 @@ export interface FormField<
   errorMessages?: { [key: string]: string };
   nestedFields?: FormField[];
   icon?: Icon & { position: 'left' | 'right' };
+  conditions?: IFieldConditions[];
 }

--- a/projects/forms/src/lib/models/IFieldConditions.ts
+++ b/projects/forms/src/lib/models/IFieldConditions.ts
@@ -1,6 +1,15 @@
 import { AbstractControl, FormGroup } from '@angular/forms';
 import { FormField } from './FormField';
 import { Observable, Subscription } from 'rxjs';
+import * as _ from 'lodash';
+import validate = WebAssembly.validate;
+
+export const areValuesEqual = (val1: any, val2: any): boolean => {
+  if (typeof val1 === 'object' && typeof val2 === 'object') {
+    return _.isEqual(val1, val2);
+  }
+  return val1 === val2;
+};
 
 export interface IFieldConditions<T = any> {
   dependOn: string;
@@ -47,12 +56,14 @@ export class FieldConditions<T = any> implements IFieldConditions<T> {
   }
 
   public start(callback?: (dependOn: string, value: T) => void): Subscription {
-    this.runAll(this.dependControl.value, callback);
-    return this.dependControl.valueChanges.subscribe((value: T) => this.runAll(value, callback));
+    console.log(this.dependOn, this.dependControl.value);
+
+    this.runAll(this.dependControl.value, true, callback);
+    return this.dependControl.valueChanges.subscribe((value: T) => this.runAll(value, false, callback));
   }
 
-  public runAll(value: T, callback?: (dependOn: string, value: T) => void): void {
-    if (this.prevValue !== value) {
+  public runAll(value: T, firstRun: boolean, callback?: (dependOn: string, value: T) => void): void {
+    if (firstRun || !areValuesEqual(this.prevValue, value)) {
       if (this.onChangeFn && typeof this.onChangeFn === 'function') {
         this.onChangeFn(value, this.fieldControl, this.dependControl);
       }

--- a/projects/forms/src/lib/models/IFieldConditions.ts
+++ b/projects/forms/src/lib/models/IFieldConditions.ts
@@ -1,0 +1,88 @@
+import { AbstractControl, FormGroup } from '@angular/forms';
+import { FormField } from './FormField';
+import { Subscription } from 'rxjs';
+
+export interface IFieldConditions<T = any> {
+  dependOn: string;
+  hideIfHasValue?: boolean;
+  showIfHasValue?: boolean;
+  disableIfHasValue?: boolean;
+  enableIfHasValue?: boolean;
+  hideIfEquals?: T;
+  showIfEquals?: T;
+  disableIfEquals?: T;
+  enabledIfEquals?: T;
+  onChangeFn?: (value: T, currentControl: AbstractControl, dependControl: AbstractControl) => any;
+}
+
+export class FieldConditions<T = any> implements IFieldConditions<T> {
+  public dependOn: string;
+  public hideIfHasValue?: boolean;
+  public showIfHasValue?: boolean;
+  public disableIfHasValue?: boolean;
+  public enableIfHasValue?: boolean;
+  public hideIfEquals?: T;
+  public showIfEquals?: T;
+  public disableIfEquals?: T;
+  public enabledIfEquals?: T;
+  public onChangeFn?: (value: T, currentControl: AbstractControl, dependControl: AbstractControl) => any;
+
+  public readonly dependControl: AbstractControl;
+
+  private get fieldControl(): AbstractControl {
+    return this.group.get(this.schema.attribute);
+  }
+
+  public constructor(private readonly group: FormGroup, private readonly schema: FormField, fieldConditions?: IFieldConditions) {
+    if (fieldConditions) {
+      Object.assign(this, fieldConditions);
+      this.dependControl = this.group.get(this.dependOn);
+      if (!this.dependControl) {
+        throw new Error(`Can't create conditional form field: no control with name ${this.dependOn} found`);
+      }
+    }
+  }
+
+  public start(): Subscription {
+    this.runAll(this.dependControl.value);
+    return this.dependControl.valueChanges.subscribe((value: any) => this.runAll(value));
+  }
+
+  public runAll(value: any): void {
+    if (this.onChangeFn && typeof this.onChangeFn === 'function') {
+      this.onChangeFn(value, this.fieldControl, this.dependControl);
+    }
+    if (!this.schema.options?.visibleFn) {
+      this.runVisibilityConditions(value);
+    } else {
+      throw new Error(`Can't create visibility conditions: visibleFn option is set and may cause conflicts`);
+    }
+    if (!this.schema.options?.readonly) {
+      this.runDisableConditions(value);
+    } else {
+      throw new Error(`Can't create disabled/enable conditions: readonly option is set and may cause conflicts`);
+    }
+  }
+
+  public run(key: string, condition: boolean, callback: (isTrue: boolean) => void): void {
+    if (this.hasOwnProperty(key)) {
+      callback(condition);
+    }
+  }
+
+  public runVisibilityConditions(value: any): void {
+    const hide = (isTrue: boolean) => (this.schema.options.hide = isTrue);
+    this.run('hideIfHasValue', this.hideIfHasValue && value, (isTrue: boolean) => hide(isTrue));
+    this.run('showIfHasValue', this.showIfHasValue && value, (isTrue: boolean) => hide(!isTrue));
+    this.run('hideIfEquals', this.hideIfEquals === value, (isTrue: boolean) => hide(isTrue));
+    this.run('showIfEquals', this.showIfEquals === value, (isTrue: boolean) => hide(!isTrue));
+  }
+
+  public runDisableConditions(value: any): void {
+    const enable = (isTrue: boolean) => (isTrue ? this.fieldControl.enable() : this.fieldControl.disable());
+    this.run('disableIfHasValue', this.disableIfHasValue && value, (isTrue: boolean) => enable(!isTrue));
+    this.run('enabledIfHasValue', this.enableIfHasValue && value, (isTrue: boolean) => enable(isTrue));
+    this.run('disableIfEquals', this.disableIfEquals === value, (isTrue: boolean) => enable(!isTrue));
+    this.run('enabledIfEquals', this.enabledIfEquals === value, (isTrue: boolean) => enable(isTrue));
+  }
+}

--- a/projects/forms/src/lib/models/IFormComponent.ts
+++ b/projects/forms/src/lib/models/IFormComponent.ts
@@ -62,7 +62,7 @@ export abstract class FormComponent<T extends FieldOptions = FieldOptions> imple
     }
   }
 
-  public onConditionalChange(dependOn: string, value: any): void {}
+  public onConditionalChange(dependOn: string, value: any, firstRun?: boolean): void {}
 
   public hide(value?: any): boolean {
     if (typeof this.schema?.options?.hide === 'function') {
@@ -134,9 +134,9 @@ export abstract class FormComponent<T extends FieldOptions = FieldOptions> imple
       .map((c) => new FieldConditions(this.group, this.schema, c))
       .forEach((conditions: FieldConditions) =>
         this.subs.push(
-          conditions.start((dependOn: string, value: any) => {
+          conditions.start((dependOn: string, value: any, firstRun: boolean) => {
             if (this.onConditionalChange) {
-              this.onConditionalChange(dependOn, value);
+              this.onConditionalChange(dependOn, value, firstRun);
             }
           }),
         ),

--- a/projects/forms/src/lib/models/IFormComponent.ts
+++ b/projects/forms/src/lib/models/IFormComponent.ts
@@ -4,7 +4,6 @@ import { AfterViewInit, Directive, Input, OnDestroy } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import { Observable, Subscription } from 'rxjs';
 import { FieldConditions } from './IFieldConditions';
-import { debounceTime } from 'rxjs/operators';
 
 export interface IFormComponent<T extends FieldOptions> {
   schema: FormField<T>;
@@ -61,8 +60,10 @@ export abstract class FormComponent<T extends FieldOptions = FieldOptions> imple
         this.isReadonly();
         this.subs.push(
           this.group.valueChanges.subscribe(() => {
-            this.hide();
-            this.isReadonly();
+            setTimeout(() => {
+              this.hide();
+              this.isReadonly();
+            });
           }),
         );
       });

--- a/projects/forms/src/lib/models/forms/AbstractMaterialReactiveFormControl.ts
+++ b/projects/forms/src/lib/models/forms/AbstractMaterialReactiveFormControl.ts
@@ -6,8 +6,7 @@ import { Subject } from 'rxjs';
 import { BaseControlValueAccessorDirective } from './BaseControlValueAccessor';
 
 @Directive()
-export abstract class AbstractMaterialReactiveFormControlDirective<T>
-  extends BaseControlValueAccessorDirective<T>
+export abstract class AbstractMaterialReactiveFormControlDirective<T> extends BaseControlValueAccessorDirective<T>
   implements MatFormFieldControl<T>, OnInit, OnDestroy {
   static nextId = 0;
   @HostBinding() readonly id: string;

--- a/projects/forms/src/lib/models/forms/AbstractMaterialReactiveFormControl.ts
+++ b/projects/forms/src/lib/models/forms/AbstractMaterialReactiveFormControl.ts
@@ -6,7 +6,8 @@ import { Subject } from 'rxjs';
 import { BaseControlValueAccessorDirective } from './BaseControlValueAccessor';
 
 @Directive()
-export abstract class AbstractMaterialReactiveFormControlDirective<T> extends BaseControlValueAccessorDirective<T>
+export abstract class AbstractMaterialReactiveFormControlDirective<T>
+  extends BaseControlValueAccessorDirective<T>
   implements MatFormFieldControl<T>, OnInit, OnDestroy {
   static nextId = 0;
   @HostBinding() readonly id: string;

--- a/projects/forms/src/lib/services/form-builder.service.ts
+++ b/projects/forms/src/lib/services/form-builder.service.ts
@@ -39,12 +39,10 @@ export class Lab900FormBuilderService {
           }),
         );
       } else {
-        let controlValue: any | null = null;
-
-        if (field.options && field.options.defaultValue) {
+        let controlValue: any | null = data?.[field.attribute];
+        if (!controlValue && field.options && field.options.defaultValue) {
           controlValue = typeof field.options.defaultValue === 'function' ? field.options.defaultValue() : field.options.defaultValue;
         }
-
         formGroup.addControl(field.attribute, new FormControl(controlValue, this.addValidators(field)));
       }
     });

--- a/projects/forms/src/lib/services/form-builder.service.ts
+++ b/projects/forms/src/lib/services/form-builder.service.ts
@@ -13,7 +13,11 @@ export class Lab900FormBuilderService {
       if (field.editType === EditType.Row && field.nestedFields) {
         // nested form groups
         if (field.attribute) {
-          formGroup.addControl(field.attribute, this.createFormGroup(field.nestedFields, null, data));
+          const nestedGroup = this.createFormGroup(field.nestedFields, null, data);
+          formGroup.addControl(field.attribute, nestedGroup);
+          if (nestedGroup.dirty) {
+            formGroup.markAsDirty();
+          }
         } else {
           formGroup = this.createFormGroup(field.nestedFields, formGroup, data);
         }
@@ -29,6 +33,9 @@ export class Lab900FormBuilderService {
           }
         }
         formGroup.addControl(field.attribute, repeaterArray);
+        if (repeaterArray.dirty) {
+          formGroup.markAsDirty();
+        }
       } else if (field.editType === EditType.DateRange) {
         const options: DateRangePickerFieldOptions = field?.options;
         formGroup.addControl(
@@ -44,8 +51,11 @@ export class Lab900FormBuilderService {
         if (field.options && field.options.defaultValue) {
           controlValue = typeof field.options.defaultValue === 'function' ? field.options.defaultValue() : field.options.defaultValue;
         }
-
-        formGroup.addControl(field.attribute, new FormControl(controlValue, this.addValidators(field)));
+        const formControl = new FormControl(controlValue, this.addValidators(field));
+        formGroup.addControl(field.attribute, formControl);
+        if (controlValue) {
+          formGroup.markAsDirty();
+        }
       }
     });
     return formGroup;

--- a/projects/forms/src/public-api.ts
+++ b/projects/forms/src/public-api.ts
@@ -6,6 +6,7 @@ export * from './lib/models/Form';
 export * from './lib/models/FormField';
 export * from './lib/models/FormGroup';
 export * from './lib/models/editType';
+export * from './lib/models/IFieldConditions';
 
 export * from './lib/components/form-container/form-container.component';
 

--- a/src/app/modules/showcase-admin/examples/configs/news-schema.config.ts
+++ b/src/app/modules/showcase-admin/examples/configs/news-schema.config.ts
@@ -102,11 +102,11 @@ export const NEWS_SCHEMA: Schema = {
       attribute: 'gameIds',
       editType: EditType.Select,
       editOptions: {
-        values: [{ value: 'pokemon', label: 'pokemon' }],
+        selectOptions: [{ value: 'pokemon', label: 'pokemon' }],
         multiple: true,
       },
       createOptions: {
-        values: [{ value: 'pokemon', label: 'pokemon' }],
+        selectOptions: [{ value: 'pokemon', label: 'pokemon' }],
         multiple: true,
       },
     },

--- a/src/app/modules/showcase-forms/examples/form-container-example/config/form-data-example.ts
+++ b/src/app/modules/showcase-forms/examples/form-container-example/config/form-data-example.ts
@@ -5,6 +5,5 @@ export const formDataExample = {
     number: 12,
   },
   firstname: 'Example',
-  name: 'data',
-  language: 'Dutch',
+  languages: 'DUT',
 };

--- a/src/app/modules/showcase-forms/examples/form-container-example/config/form-data-example.ts
+++ b/src/app/modules/showcase-forms/examples/form-container-example/config/form-data-example.ts
@@ -1,9 +1,9 @@
 export const formDataExample = {
   address: {
-    country: 'Belgium',
     street: 'Sesamstraat',
     number: 12,
   },
   firstname: 'Example',
-  languages: 'DUT',
+  country: 'BE',
+  languages: 'VL',
 };

--- a/src/app/modules/showcase-forms/examples/form-container-example/config/form-data-example.ts
+++ b/src/app/modules/showcase-forms/examples/form-container-example/config/form-data-example.ts
@@ -4,8 +4,7 @@ export const formDataExample = {
     number: 12,
   },
   firstname: 'Example',
-  country: 'BE',
-  languages: 'VL',
-  dialects: 'ANT',
-  subDialects: 'PLAT_ANT',
+  incidentId: 1,
+  registerPoint: 'WELCOME',
+  locationId: 2,
 };

--- a/src/app/modules/showcase-forms/examples/form-container-example/config/form-data-example.ts
+++ b/src/app/modules/showcase-forms/examples/form-container-example/config/form-data-example.ts
@@ -6,4 +6,5 @@ export const formDataExample = {
   firstname: 'Example',
   country: 'BE',
   languages: 'VL',
+  dialects: 'ANT',
 };

--- a/src/app/modules/showcase-forms/examples/form-container-example/config/form-data-example.ts
+++ b/src/app/modules/showcase-forms/examples/form-container-example/config/form-data-example.ts
@@ -1,4 +1,5 @@
 export const formDataExample = {
+  uniqueNumber: '10',
   address: {
     street: 'Sesamstraat',
     number: 12,

--- a/src/app/modules/showcase-forms/examples/form-container-example/config/form-data-example.ts
+++ b/src/app/modules/showcase-forms/examples/form-container-example/config/form-data-example.ts
@@ -6,5 +6,5 @@ export const formDataExample = {
   firstname: 'Example',
   incidentId: 1,
   registerPoint: 'WELCOME',
-  locationId: 2,
+  locationId: 1,
 };

--- a/src/app/modules/showcase-forms/examples/form-container-example/config/form-data-example.ts
+++ b/src/app/modules/showcase-forms/examples/form-container-example/config/form-data-example.ts
@@ -6,4 +6,5 @@ export const formDataExample = {
   },
   firstname: 'Example',
   name: 'data',
+  language: 'Dutch',
 };

--- a/src/app/modules/showcase-forms/examples/form-container-example/config/form-data-example.ts
+++ b/src/app/modules/showcase-forms/examples/form-container-example/config/form-data-example.ts
@@ -7,4 +7,5 @@ export const formDataExample = {
   country: 'BE',
   languages: 'VL',
   dialects: 'ANT',
+  subDialects: 'PLAT_ANT',
 };

--- a/src/app/modules/showcase-forms/examples/form-container-example/config/form-data-example.ts
+++ b/src/app/modules/showcase-forms/examples/form-container-example/config/form-data-example.ts
@@ -1,11 +1,9 @@
 export const formDataExample = {
-  uniqueNumber: '10',
   address: {
+    country: 'Belgium',
     street: 'Sesamstraat',
     number: 12,
   },
   firstname: 'Example',
-  incidentId: 1,
-  registerPoint: 'WELCOME',
-  locationId: 1,
+  languages: 'DUT',
 };

--- a/src/app/modules/showcase-forms/examples/form-container-example/config/form-fields-example.ts
+++ b/src/app/modules/showcase-forms/examples/form-container-example/config/form-fields-example.ts
@@ -1,11 +1,11 @@
-import { Form, EditType } from '@lab900/forms';
-import { Observable, of } from 'rxjs';
-import { delay, map, tap } from 'rxjs/operators';
+import { EditType, Form } from '@lab900/forms';
+import { of } from 'rxjs';
+import { delay } from 'rxjs/operators';
 
 export const formFieldsExample: Form = {
   readonly: false,
   fields: [
-    {
+    /*    {
       editType: EditType.Row,
       nestedFields: [
         {
@@ -47,7 +47,7 @@ export const formFieldsExample: Form = {
           },
         },
       ],
-    },
+    },*/
     {
       editType: EditType.Row,
       nestedFields: [
@@ -99,7 +99,7 @@ export const formFieldsExample: Form = {
               enableIfHasValue: true,
               conditionalOptions: (value: string) => {
                 if (value) {
-                  return value === 'VL' ? [{ label: 'Antwerps', value: 'ANT' }] : [{ label: 'Brits', value: 'BR' }];
+                  return value === 'VL' ? of([{ label: 'Antwerps', value: 'ANT' }]).pipe(delay(2000)) : [{ label: 'Brits', value: 'BR' }];
                 }
                 return [];
               },

--- a/src/app/modules/showcase-forms/examples/form-container-example/config/form-fields-example.ts
+++ b/src/app/modules/showcase-forms/examples/form-container-example/config/form-fields-example.ts
@@ -1,23 +1,8 @@
-import { EditType, Form } from '@lab900/forms';
-import { of } from 'rxjs';
-import { delay } from 'rxjs/operators';
-import { AbstractControl } from '@angular/forms';
-
-const incidents = [
-  {
-    id: 1,
-    name: 'x',
-    areas: [
-      { type: 'WELCOME', name: 'xxxx welcome', id: 1 },
-      { type: 'CALLS', name: 'xxxx calls', id: 2 },
-    ],
-  },
-];
+import { Form, EditType } from '@lab900/forms';
 
 export const formFieldsExample: Form = {
-  readonly: false,
   fields: [
-    /*    {
+    {
       editType: EditType.Row,
       nestedFields: [
         {
@@ -43,11 +28,20 @@ export const formFieldsExample: Form = {
       editType: EditType.Row,
       nestedFields: [
         {
+          title: 'Country',
+          attribute: 'country',
+          editType: EditType.Input,
+          options: {
+            colspan: 12,
+          },
+        },
+        {
           title: 'Street',
           attribute: 'street',
           editType: EditType.Input,
           options: {
             colspan: 6,
+            readonly: true,
           },
         },
         {
@@ -59,62 +53,27 @@ export const formFieldsExample: Form = {
           },
         },
       ],
-    },*/
+    },
     {
       editType: EditType.Row,
       nestedFields: [
         {
-          title: 'incidentId',
-          attribute: 'incidentId',
+          title: 'languages',
+          attribute: 'languages',
           editType: EditType.Select,
           options: {
+            readonly: true,
             colspan: 12,
-            selectOptions: of(incidents.map((i) => ({ value: i.id, label: i.name }))).pipe(delay(100)),
-          },
-        },
-        {
-          title: 'registerPoint',
-          attribute: 'registerPoint',
-          editType: EditType.Select,
-          conditions: [
-            {
-              dependOn: 'incidentId',
-              enableIfHasValue: true,
-              conditionalOptions: (value: number) => {
-                if (value) {
-                  return of(['WELCOME', 'CALLS'].map((v) => ({ value: v, label: v }))).pipe(delay(100));
-                }
-                return of([]);
+            selectOptions: [
+              {
+                value: 'Dutch',
+                label: 'DUT',
               },
-            },
-          ],
-          options: {
-            colspan: 12,
-            readonly: (d: any) => {
-              return !!d?.incidentId;
-            },
-          },
-        },
-        {
-          title: 'locationId',
-          attribute: 'locationId',
-          editType: EditType.Select,
-          conditions: [
-            {
-              dependOn: 'registerPoint',
-              enableIfHasValue: true,
-              conditionalOptions: (value: string, currentControl: AbstractControl) => {
-                if (value) {
-                  const incidentId = currentControl.parent.get('incidentId').value;
-                  const areas = incidents.find((i) => i.id === incidentId)?.areas;
-                  return [...(areas || [])].filter((a) => a.type === value).map((i) => ({ value: i.id, label: i.name }));
-                }
-                return [];
+              {
+                value: 'English',
+                label: 'ENG',
               },
-            },
-          ],
-          options: {
-            colspan: 12,
+            ],
           },
         },
       ],

--- a/src/app/modules/showcase-forms/examples/form-container-example/config/form-fields-example.ts
+++ b/src/app/modules/showcase-forms/examples/form-container-example/config/form-fields-example.ts
@@ -1,6 +1,6 @@
 import { EditType, Form } from '@lab900/forms';
 import { of } from 'rxjs';
-import { delay, tap } from 'rxjs/operators';
+import { delay } from 'rxjs/operators';
 import { AbstractControl } from '@angular/forms';
 
 const incidents = [
@@ -68,6 +68,7 @@ export const formFieldsExample: Form = {
           attribute: 'incidentId',
           editType: EditType.Select,
           options: {
+            readonly: true,
             colspan: 12,
             selectOptions: of(incidents.map((i) => ({ value: i.id, label: i.name }))).pipe(delay(100)),
           },

--- a/src/app/modules/showcase-forms/examples/form-container-example/config/form-fields-example.ts
+++ b/src/app/modules/showcase-forms/examples/form-container-example/config/form-fields-example.ts
@@ -1,6 +1,9 @@
 import { Form, EditType } from '@lab900/forms';
+import { Observable, of } from 'rxjs';
+import { delay, map, tap } from 'rxjs/operators';
 
 export const formFieldsExample: Form = {
+  readonly: false,
   fields: [
     {
       editType: EditType.Row,
@@ -20,22 +23,6 @@ export const formFieldsExample: Form = {
           options: {
             colspan: 6,
           },
-          conditions: [
-            {
-              dependOn: 'name',
-              hideIfHasValue: true,
-            },
-            {
-              dependOn: 'address.country',
-              disableIfEquals: 'Belgium',
-            },
-            {
-              dependOn: 'languages',
-              onChangeFn: (value: string, fieldControl) => {
-                fieldControl.setValue(value);
-              },
-            },
-          ],
         },
       ],
     },
@@ -43,14 +30,6 @@ export const formFieldsExample: Form = {
       attribute: 'address',
       editType: EditType.Row,
       nestedFields: [
-        {
-          title: 'Country',
-          attribute: 'country',
-          editType: EditType.Input,
-          options: {
-            colspan: 12,
-          },
-        },
         {
           title: 'Street',
           attribute: 'street',
@@ -73,22 +52,61 @@ export const formFieldsExample: Form = {
       editType: EditType.Row,
       nestedFields: [
         {
+          title: 'country',
+          attribute: 'country',
+          editType: EditType.Select,
+          options: {
+            colspan: 12,
+            selectOptions: of([
+              {
+                label: 'Belgium',
+                value: 'BE',
+              },
+              {
+                label: 'England',
+                value: 'EN',
+              },
+            ]).pipe(delay(1000)),
+          },
+        },
+        {
           title: 'languages',
           attribute: 'languages',
           editType: EditType.Select,
+          conditions: [
+            {
+              dependOn: 'country',
+              enableIfHasValue: true,
+              conditionalOptions: (value: string) => {
+                if (value) {
+                  return of(value === 'BE' ? [{ label: 'Vlaams', value: 'VL' }] : [{ label: 'Engels', value: 'EN' }]).pipe(delay(5000));
+                }
+                return of([]);
+              },
+            },
+          ],
           options: {
-            readonly: true,
             colspan: 12,
-            selectOptions: [
-              {
-                label: 'Dutch',
-                value: 'DUT',
+          },
+        },
+        {
+          title: 'dialects',
+          attribute: 'dialects',
+          editType: EditType.Select,
+          conditions: [
+            {
+              dependOn: 'languages',
+              enableIfHasValue: true,
+              conditionalOptions: (value: string) => {
+                if (value) {
+                  return value === 'VL' ? [{ label: 'Antwerps', value: 'ANT' }] : [{ label: 'Brits', value: 'BR' }];
+                }
+                return [];
               },
-              {
-                label: 'English',
-                value: 'ENG',
-              },
-            ],
+            },
+          ],
+          options: {
+            colspan: 12,
           },
         },
       ],

--- a/src/app/modules/showcase-forms/examples/form-container-example/config/form-fields-example.ts
+++ b/src/app/modules/showcase-forms/examples/form-container-example/config/form-fields-example.ts
@@ -68,7 +68,6 @@ export const formFieldsExample: Form = {
           attribute: 'incidentId',
           editType: EditType.Select,
           options: {
-            readonly: true,
             colspan: 12,
             selectOptions: of(incidents.map((i) => ({ value: i.id, label: i.name }))).pipe(delay(100)),
           },
@@ -91,6 +90,9 @@ export const formFieldsExample: Form = {
           ],
           options: {
             colspan: 12,
+            readonly: (d: any) => {
+              return !!d?.incidentId;
+            },
           },
         },
         {

--- a/src/app/modules/showcase-forms/examples/form-container-example/config/form-fields-example.ts
+++ b/src/app/modules/showcase-forms/examples/form-container-example/config/form-fields-example.ts
@@ -1,19 +1,18 @@
 import { EditType, Form } from '@lab900/forms';
 import { of } from 'rxjs';
 import { delay, tap } from 'rxjs/operators';
+import { AbstractControl } from '@angular/forms';
 
 const incidents = [
   {
     id: 1,
     name: 'x',
     areas: [
-      { type: 'WELCOME', name: 'xxxx', id: 1 },
-      { type: 'CALL', name: 'xxxx', id: 2 },
+      { type: 'WELCOME', name: 'xxxx welcome', id: 1 },
+      { type: 'CALLS', name: 'xxxx calls', id: 2 },
     ],
   },
 ];
-
-let areas;
 
 export const formFieldsExample: Form = {
   readonly: false,
@@ -83,10 +82,7 @@ export const formFieldsExample: Form = {
               enableIfHasValue: true,
               conditionalOptions: (value: number) => {
                 if (value) {
-                  return of(['WELCOME', 'CALLS'].map((v) => ({ value: v, label: v }))).pipe(
-                    delay(100),
-                    tap((_) => (areas = incidents[0].areas)),
-                  );
+                  return of(['WELCOME', 'CALLS'].map((v) => ({ value: v, label: v }))).pipe(delay(100));
                 }
                 return of([]);
               },
@@ -104,9 +100,11 @@ export const formFieldsExample: Form = {
             {
               dependOn: 'registerPoint',
               enableIfHasValue: true,
-              conditionalOptions: (value: number) => {
+              conditionalOptions: (value: string, currentControl: AbstractControl) => {
                 if (value) {
-                  return areas || [];
+                  const incidentId = currentControl.parent.get('incidentId').value;
+                  const areas = incidents.find((i) => i.id === incidentId)?.areas;
+                  return [...(areas || [])].filter((a) => a.type === value).map((i) => ({ value: i.id, label: i.name }));
                 }
                 return [];
               },

--- a/src/app/modules/showcase-forms/examples/form-container-example/config/form-fields-example.ts
+++ b/src/app/modules/showcase-forms/examples/form-container-example/config/form-fields-example.ts
@@ -1,6 +1,19 @@
 import { EditType, Form } from '@lab900/forms';
 import { of } from 'rxjs';
-import { delay } from 'rxjs/operators';
+import { delay, tap } from 'rxjs/operators';
+
+const incidents = [
+  {
+    id: 1,
+    name: 'x',
+    areas: [
+      { type: 'WELCOME', name: 'xxxx', id: 1 },
+      { type: 'CALL', name: 'xxxx', id: 2 },
+    ],
+  },
+];
+
+let areas;
 
 export const formFieldsExample: Form = {
   readonly: false,
@@ -52,41 +65,28 @@ export const formFieldsExample: Form = {
       editType: EditType.Row,
       nestedFields: [
         {
-          title: 'country',
-          attribute: 'country',
+          title: 'incidentId',
+          attribute: 'incidentId',
           editType: EditType.Select,
           options: {
             colspan: 12,
-            selectOptions: of([
-              {
-                label: 'Belgium',
-                value: 'BE',
-              },
-              {
-                label: 'England',
-                value: 'EN',
-              },
-            ]).pipe(delay(1000)),
+            selectOptions: of(incidents.map((i) => ({ value: i.id, label: i.name }))).pipe(delay(100)),
           },
         },
         {
-          title: 'languages',
-          attribute: 'languages',
+          title: 'registerPoint',
+          attribute: 'registerPoint',
           editType: EditType.Select,
           conditions: [
             {
-              dependOn: 'country',
+              dependOn: 'incidentId',
               enableIfHasValue: true,
-              conditionalOptions: (value: string) => {
+              conditionalOptions: (value: number) => {
                 if (value) {
-                  return of(
-                    value === 'BE'
-                      ? [
-                          { label: 'Vlaams', value: 'VL' },
-                          { label: 'Waals', value: 'WL' },
-                        ]
-                      : [{ label: 'Engels', value: 'EN' }],
-                  ).pipe(delay(5000));
+                  return of(['WELCOME', 'CALLS'].map((v) => ({ value: v, label: v }))).pipe(
+                    delay(100),
+                    tap((_) => (areas = incidents[0].areas)),
+                  );
                 }
                 return of([]);
               },
@@ -97,38 +97,16 @@ export const formFieldsExample: Form = {
           },
         },
         {
-          title: 'dialects',
-          attribute: 'dialects',
+          title: 'locationId',
+          attribute: 'locationId',
           editType: EditType.Select,
           conditions: [
             {
-              dependOn: 'languages',
+              dependOn: 'registerPoint',
               enableIfHasValue: true,
-              conditionalOptions: (value: string) => {
+              conditionalOptions: (value: number) => {
                 if (value) {
-                  return value === 'VL' ? of([{ label: 'Antwerps', value: 'ANT' }]).pipe(delay(2000)) : [{ label: 'Brits', value: 'BR' }];
-                }
-                return [];
-              },
-            },
-          ],
-          options: {
-            colspan: 12,
-          },
-        },
-        {
-          title: 'sub dialects',
-          attribute: 'subDialects',
-          editType: EditType.Select,
-          conditions: [
-            {
-              dependOn: 'dialects',
-              enableIfHasValue: true,
-              conditionalOptions: (value: string) => {
-                if (value) {
-                  return value === 'ANT'
-                    ? of([{ label: 'Plat antwerps', value: 'PLAT_ANT' }]).pipe(delay(2000))
-                    : [{ label: 'Heel Brits', value: 'HEEL_BR' }];
+                  return areas || [];
                 }
                 return [];
               },

--- a/src/app/modules/showcase-forms/examples/form-container-example/config/form-fields-example.ts
+++ b/src/app/modules/showcase-forms/examples/form-container-example/config/form-fields-example.ts
@@ -20,6 +20,22 @@ export const formFieldsExample: Form = {
           options: {
             colspan: 6,
           },
+          conditions: [
+            {
+              dependOn: 'name',
+              hideIfHasValue: true,
+            },
+            {
+              dependOn: 'address.country',
+              disableIfEquals: 'Belgium',
+            },
+            {
+              dependOn: 'languages',
+              onChangeFn: (value: string, fieldControl) => {
+                fieldControl.setValue(value);
+              },
+            },
+          ],
         },
       ],
     },
@@ -65,12 +81,12 @@ export const formFieldsExample: Form = {
             colspan: 12,
             selectOptions: [
               {
-                value: 'Dutch',
-                label: 'DUT',
+                label: 'Dutch',
+                value: 'DUT',
               },
               {
-                value: 'English',
-                label: 'ENG',
+                label: 'English',
+                value: 'ENG',
               },
             ],
           },

--- a/src/app/modules/showcase-forms/examples/form-container-example/config/form-fields-example.ts
+++ b/src/app/modules/showcase-forms/examples/form-container-example/config/form-fields-example.ts
@@ -79,7 +79,14 @@ export const formFieldsExample: Form = {
               enableIfHasValue: true,
               conditionalOptions: (value: string) => {
                 if (value) {
-                  return of(value === 'BE' ? [{ label: 'Vlaams', value: 'VL' }] : [{ label: 'Engels', value: 'EN' }]).pipe(delay(5000));
+                  return of(
+                    value === 'BE'
+                      ? [
+                          { label: 'Vlaams', value: 'VL' },
+                          { label: 'Waals', value: 'WL' },
+                        ]
+                      : [{ label: 'Engels', value: 'EN' }],
+                  ).pipe(delay(5000));
                 }
                 return of([]);
               },
@@ -100,6 +107,28 @@ export const formFieldsExample: Form = {
               conditionalOptions: (value: string) => {
                 if (value) {
                   return value === 'VL' ? of([{ label: 'Antwerps', value: 'ANT' }]).pipe(delay(2000)) : [{ label: 'Brits', value: 'BR' }];
+                }
+                return [];
+              },
+            },
+          ],
+          options: {
+            colspan: 12,
+          },
+        },
+        {
+          title: 'sub dialects',
+          attribute: 'subDialects',
+          editType: EditType.Select,
+          conditions: [
+            {
+              dependOn: 'dialects',
+              enableIfHasValue: true,
+              conditionalOptions: (value: string) => {
+                if (value) {
+                  return value === 'ANT'
+                    ? of([{ label: 'Plat antwerps', value: 'PLAT_ANT' }]).pipe(delay(2000))
+                    : [{ label: 'Heel Brits', value: 'HEEL_BR' }];
                 }
                 return [];
               },

--- a/src/app/modules/showcase-forms/examples/form-container-example/config/form-fields-example.ts
+++ b/src/app/modules/showcase-forms/examples/form-container-example/config/form-fields-example.ts
@@ -63,7 +63,7 @@ export const formFieldsExample: Form = {
           options: {
             readonly: true,
             colspan: 12,
-            values: [
+            selectOptions: [
               {
                 value: 'Dutch',
                 label: 'DUT',

--- a/src/app/modules/showcase-forms/examples/form-container-example/form-container-readonly-example.component.ts
+++ b/src/app/modules/showcase-forms/examples/form-container-example/form-container-readonly-example.component.ts
@@ -9,8 +9,14 @@ import { formDataExample } from './config/form-data-example';
 })
 export class FormContainerReadonlyExampleComponent {
   public formFields: Form = { ...formFieldsExample, readonly: true };
-  public formData = formDataExample;
+  public formData;
 
   @ViewChild('lab900FormContainer')
   private formContainer: FormContainerComponent<any>;
+
+  public constructor() {
+    setTimeout(() => (this.formData = formDataExample), 500);
+    setTimeout(() => (this.formData = { ...formDataExample, languages: 'ENG' }), 3000);
+    setTimeout(() => (this.formData = { ...formDataExample, name: 'test' }), 6000);
+  }
 }

--- a/src/app/modules/showcase-forms/examples/form-container-example/form-container-readonly-example.component.ts
+++ b/src/app/modules/showcase-forms/examples/form-container-example/form-container-readonly-example.component.ts
@@ -5,8 +5,7 @@ import { formDataExample } from './config/form-data-example';
 
 @Component({
   selector: 'lab900-form-container-readonly-example',
-  // template: `<lab900-form-container #lab900FormContainer [schema]="formFields" [data]="formData"></lab900-form-container>`,
-  template: ``,
+  template: `<lab900-form-container #lab900FormContainer [schema]="formFields" [data]="formData"></lab900-form-container>`,
 })
 export class FormContainerReadonlyExampleComponent {
   public formFields: Form = { ...formFieldsExample, readonly: true };
@@ -17,6 +16,6 @@ export class FormContainerReadonlyExampleComponent {
 
   public constructor() {
     setTimeout(() => (this.formData = formDataExample), 500);
-    // setTimeout(() => (this.formData = { ...formDataExample, country: 'EN' }), 3000);
+    setTimeout(() => (this.formData = { ...formDataExample, country: 'EN' }), 3000);
   }
 }

--- a/src/app/modules/showcase-forms/examples/form-container-example/form-container-readonly-example.component.ts
+++ b/src/app/modules/showcase-forms/examples/form-container-example/form-container-readonly-example.component.ts
@@ -5,7 +5,8 @@ import { formDataExample } from './config/form-data-example';
 
 @Component({
   selector: 'lab900-form-container-readonly-example',
-  template: `<lab900-form-container #lab900FormContainer [schema]="formFields" [data]="formData"></lab900-form-container>`,
+  // template: `<lab900-form-container #lab900FormContainer [schema]="formFields" [data]="formData"></lab900-form-container>`,
+  template: ``,
 })
 export class FormContainerReadonlyExampleComponent {
   public formFields: Form = { ...formFieldsExample, readonly: true };
@@ -16,6 +17,6 @@ export class FormContainerReadonlyExampleComponent {
 
   public constructor() {
     setTimeout(() => (this.formData = formDataExample), 500);
-    setTimeout(() => (this.formData = { ...formDataExample, country: 'EN' }), 3000);
+    // setTimeout(() => (this.formData = { ...formDataExample, country: 'EN' }), 3000);
   }
 }

--- a/src/app/modules/showcase-forms/examples/form-container-example/form-container-readonly-example.component.ts
+++ b/src/app/modules/showcase-forms/examples/form-container-example/form-container-readonly-example.component.ts
@@ -16,6 +16,6 @@ export class FormContainerReadonlyExampleComponent {
 
   public constructor() {
     setTimeout(() => (this.formData = formDataExample), 500);
-    setTimeout(() => (this.formData = { ...formDataExample, country: 'EN' }), 10000);
+    setTimeout(() => (this.formData = { ...formDataExample, name: 'fdsfdsfdsjfs' }), 10000);
   }
 }

--- a/src/app/modules/showcase-forms/examples/form-container-example/form-container-readonly-example.component.ts
+++ b/src/app/modules/showcase-forms/examples/form-container-example/form-container-readonly-example.component.ts
@@ -16,7 +16,6 @@ export class FormContainerReadonlyExampleComponent {
 
   public constructor() {
     setTimeout(() => (this.formData = formDataExample), 500);
-    setTimeout(() => (this.formData = { ...formDataExample, languages: 'ENG' }), 3000);
-    setTimeout(() => (this.formData = { ...formDataExample, name: 'test' }), 6000);
+    setTimeout(() => (this.formData = { ...formDataExample, country: 'EN' }), 3000);
   }
 }

--- a/src/app/modules/showcase-forms/examples/form-container-example/form-container-readonly-example.component.ts
+++ b/src/app/modules/showcase-forms/examples/form-container-example/form-container-readonly-example.component.ts
@@ -9,13 +9,8 @@ import { formDataExample } from './config/form-data-example';
 })
 export class FormContainerReadonlyExampleComponent {
   public formFields: Form = { ...formFieldsExample, readonly: true };
-  public formData;
+  public formData = formDataExample;
 
   @ViewChild('lab900FormContainer')
   private formContainer: FormContainerComponent<any>;
-
-  public constructor() {
-    setTimeout(() => (this.formData = formDataExample), 500);
-    setTimeout(() => (this.formData = { ...formDataExample, name: 'fdsfdsfdsjfs' }), 10000);
-  }
 }

--- a/src/app/modules/showcase-forms/examples/form-container-example/form-container-readonly-example.component.ts
+++ b/src/app/modules/showcase-forms/examples/form-container-example/form-container-readonly-example.component.ts
@@ -16,6 +16,6 @@ export class FormContainerReadonlyExampleComponent {
 
   public constructor() {
     setTimeout(() => (this.formData = formDataExample), 500);
-    setTimeout(() => (this.formData = { ...formDataExample, country: 'EN' }), 3000);
+    setTimeout(() => (this.formData = { ...formDataExample, country: 'EN' }), 10000);
   }
 }

--- a/src/app/modules/showcase-forms/examples/form-field-autocomplete-example/form-field-autocomplete-example.component.ts
+++ b/src/app/modules/showcase-forms/examples/form-field-autocomplete-example/form-field-autocomplete-example.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { Form, EditType } from '@lab900/forms';
+import { Form, EditType, ValueLabel } from '@lab900/forms';
 import { of } from 'rxjs';
 
 @Component({
@@ -8,7 +8,7 @@ import { of } from 'rxjs';
   template: '<lab900-form-container [schema]="formSchema"></lab900-form-container>',
 })
 export class FormFieldAutocompleteExampleComponent {
-  public options: { name: string }[] = [{ name: 'Mary' }, { name: 'Shelley' }, { name: 'Igor' }];
+  public options: ValueLabel[] = [{ name: 'Mary' }, { name: 'Shelley' }, { name: 'Igor' }].map((value) => ({ value, label: value.name }));
 
   public formSchema: Form = {
     fields: [
@@ -19,8 +19,8 @@ export class FormFieldAutocompleteExampleComponent {
         options: {
           autocompleteOptions: (value: string) => of(this.filter(value)),
           displayInputFn: (user: { name: string }) => user?.name ?? '',
-          displayOptionFn: (user: { name: string }) => {
-            const userName = user?.name ?? '';
+          displayOptionFn: (user: ValueLabel) => {
+            const userName = user?.label ?? '';
             const image =
               'https://firebasestorage.googleapis.com/v0/b/lab900-website-production.appspot.com/o/public%2Fproject-images%2Fyou%2Fyou-mockup.svg?alt=media';
             return `<div class="user-option"><img width="20" height="20" src="${image}"> ${userName}</div>`;
@@ -30,8 +30,8 @@ export class FormFieldAutocompleteExampleComponent {
     ],
   };
 
-  private filter(value: string): { name: string }[] {
+  private filter(value: string): ValueLabel[] {
     const filterValue = value.toLowerCase();
-    return this.options.filter((option: { name: string }) => option.name.toLowerCase().includes(filterValue));
+    return this.options.filter((option: ValueLabel) => option.label.toLowerCase().includes(filterValue));
   }
 }

--- a/src/app/modules/showcase-forms/examples/form-field-autocomplete-example/form-field-autocomplete-example.component.ts
+++ b/src/app/modules/showcase-forms/examples/form-field-autocomplete-example/form-field-autocomplete-example.component.ts
@@ -17,7 +17,7 @@ export class FormFieldAutocompleteExampleComponent {
         title: 'Search a value',
         editType: EditType.Autocomplete,
         options: {
-          getOptionsFn: (value: string) => of(this.filter(value)),
+          autocompleteOptions: (value: string) => of(this.filter(value)),
           displayInputFn: (user: { name: string }) => user?.name ?? '',
           displayOptionFn: (user: { name: string }) => {
             const userName = user?.name ?? '';

--- a/src/app/modules/showcase-forms/examples/form-field-autocomplete-example/form-field-autocomplete-multiple-example.component.ts
+++ b/src/app/modules/showcase-forms/examples/form-field-autocomplete-example/form-field-autocomplete-multiple-example.component.ts
@@ -16,7 +16,7 @@ export class FormFieldAutocompleteMultipleExampleComponent {
         title: 'Search a value',
         editType: EditType.AutocompleteMultiple,
         options: {
-          getOptionsFn: (value: string) => of(this.filter(value)),
+          autocompleteOptions: (value: string) => of(this.filter(value)),
           displayInputFn: (user: { name: string }) => (user && user.name) || '',
           displayOptionFn: (user: { name: string }) => (user && user.name) || '',
         },

--- a/src/app/modules/showcase-forms/examples/form-field-autocomplete-example/form-field-autocomplete-multiple-example.component.ts
+++ b/src/app/modules/showcase-forms/examples/form-field-autocomplete-example/form-field-autocomplete-multiple-example.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { Form, EditType } from '@lab900/forms';
+import { Form, EditType, ValueLabel } from '@lab900/forms';
 import { of } from 'rxjs';
 
 @Component({
@@ -7,7 +7,7 @@ import { of } from 'rxjs';
   template: '<lab900-form-container #formContainer [schema]="formSchema"></lab900-form-container>',
 })
 export class FormFieldAutocompleteMultipleExampleComponent {
-  public options: { name: string }[] = [{ name: 'Mary' }, { name: 'Shelley' }, { name: 'Igor' }];
+  public options: ValueLabel[] = [{ name: 'Mary' }, { name: 'Shelley' }, { name: 'Igor' }].map((value) => ({ value, label: value.name }));
 
   public formSchema: Form = {
     fields: [
@@ -17,15 +17,15 @@ export class FormFieldAutocompleteMultipleExampleComponent {
         editType: EditType.AutocompleteMultiple,
         options: {
           autocompleteOptions: (value: string) => of(this.filter(value)),
-          displayInputFn: (user: { name: string }) => (user && user.name) || '',
-          displayOptionFn: (user: { name: string }) => (user && user.name) || '',
+          displayInputFn: (user: { name: string }) => user?.name ?? '',
+          displayOptionFn: (user: ValueLabel) => user?.label,
         },
       },
     ],
   };
 
-  private filter(value: string): { name: string }[] {
+  private filter(value: string): ValueLabel[] {
     const filterValue = value.toLowerCase();
-    return this.options.filter((option: { name: string }) => option.name.toLowerCase().includes(filterValue));
+    return this.options.filter((option: ValueLabel) => option.label.toLowerCase().includes(filterValue));
   }
 }

--- a/src/app/modules/showcase-forms/examples/form-field-button-toggle-example/form-field-button-toggle-example.component.ts
+++ b/src/app/modules/showcase-forms/examples/form-field-button-toggle-example/form-field-button-toggle-example.component.ts
@@ -17,7 +17,7 @@ export class FormFieldButtonToggleExampleComponent {
         editType: EditType.ButtonToggle,
         options: {
           required: true,
-          values: [
+          buttonOptions: [
             {
               value: true,
               label: 'yes',
@@ -39,7 +39,7 @@ export class FormFieldButtonToggleExampleComponent {
             editType: EditType.ButtonToggle,
             options: {
               required: true,
-              values: [
+              buttonOptions: [
                 {
                   value: 'edit',
                   icon: { name: 'edit' },

--- a/src/app/modules/showcase-forms/examples/form-field-inputs-example/form-field-inputs-example.component.ts
+++ b/src/app/modules/showcase-forms/examples/form-field-inputs-example/form-field-inputs-example.component.ts
@@ -64,7 +64,7 @@ export class FormFieldInputsExampleComponent {
         editType: EditType.Select,
         options: {
           hint: { value: 'Show a hint', hideHintOnValidValue: true },
-          values: [
+          selectOptions: [
             { value: 1, label: '1' },
             { value: 2, label: '2' },
           ],

--- a/src/app/modules/showcase-forms/examples/form-field-radio-buttons-example/form-field-radio-buttons-example.component.ts
+++ b/src/app/modules/showcase-forms/examples/form-field-radio-buttons-example/form-field-radio-buttons-example.component.ts
@@ -14,7 +14,7 @@ export class FormFieldRadioButtonsExampleComponent {
         editType: EditType.RadioButtons,
         options: {
           required: true,
-          values: [
+          radioOptions: [
             {
               value: true,
               label: 'yes',

--- a/src/app/modules/showcase-forms/examples/form-field-repeater-advanced-example/form-field-repeater-advanced-example.component.ts
+++ b/src/app/modules/showcase-forms/examples/form-field-repeater-advanced-example/form-field-repeater-advanced-example.component.ts
@@ -12,7 +12,6 @@ export class FormFieldRepeaterAdvancedExampleComponent {
         attribute: 'repeater',
         title: 'Add something nested',
         editType: EditType.Repeater,
-        options: {},
         nestedFields: [
           {
             attribute: 'value',

--- a/src/app/modules/showcase-forms/examples/form-field-repeater-example/form-field-repeater-example.component.ts
+++ b/src/app/modules/showcase-forms/examples/form-field-repeater-example/form-field-repeater-example.component.ts
@@ -1,19 +1,35 @@
-import { Component } from '@angular/core';
-import { Form, EditType } from '@lab900/forms';
+import { Component, ViewChild } from '@angular/core';
+import { EditType, Form, FormContainerComponent } from '@lab900/forms';
 
 @Component({
   selector: 'lab900-form-field-repeater-example',
-  template: '<lab900-form-container [schema]="formSchema"></lab900-form-container>',
+  template: '<lab900-form-container [schema]="formSchema" (click)="logValue(form)" #form></lab900-form-container>',
 })
 export class FormFieldRepeaterExampleComponent {
+  @ViewChild(FormContainerComponent, { static: true })
+  public form: FormContainerComponent<any>;
+
   public formSchema: Form = {
     fields: [
       {
         attribute: 'repeater',
         title: 'Add something',
         editType: EditType.Repeater,
-        nestedFields: [{ attribute: 'value', editType: EditType.Input, title: 'Repeated field' }],
+        nestedFields: [
+          {
+            attribute: 'value',
+            editType: EditType.Input,
+            title: 'Repeated field',
+            options: {
+              defaultValue: () => '234',
+            },
+          },
+        ],
       },
     ],
   };
+
+  logValue(form: any) {
+    console.log(form);
+  }
 }

--- a/src/app/modules/showcase-forms/examples/form-field-select-example/form-field-select-example.component.ts
+++ b/src/app/modules/showcase-forms/examples/form-field-select-example/form-field-select-example.component.ts
@@ -13,7 +13,7 @@ export class FormFieldSelectExampleComponent {
         title: 'Select yes or no',
         editType: EditType.Select,
         options: {
-          values: [
+          selectOptions: [
             {
               value: true,
               label: 'yes',

--- a/src/app/modules/showcase-forms/showcase-forms-routing.module.ts
+++ b/src/app/modules/showcase-forms/showcase-forms-routing.module.ts
@@ -39,7 +39,7 @@ const routes: Routes = [
     'Dynamic forms',
     [
       new ShowcaseExample(FormContainerExampleComponent, 'Form Container'),
-      new ShowcaseExample(FormContainerReadonlyExampleComponent, 'Form Container Readonly', 'form-container-example'),
+      // new ShowcaseExample(FormContainerReadonlyExampleComponent, 'Form Container Readonly', 'form-container-example'),
     ],
     'guides/forms/creating-forms.md',
   ),

--- a/src/app/modules/showcase-forms/showcase-forms-routing.module.ts
+++ b/src/app/modules/showcase-forms/showcase-forms-routing.module.ts
@@ -39,7 +39,7 @@ const routes: Routes = [
     'Dynamic forms',
     [
       new ShowcaseExample(FormContainerExampleComponent, 'Form Container'),
-      // new ShowcaseExample(FormContainerReadonlyExampleComponent, 'Form Container Readonly', 'form-container-example'),
+      new ShowcaseExample(FormContainerReadonlyExampleComponent, 'Form Container Readonly', 'form-container-example'),
     ],
     'guides/forms/creating-forms.md',
   ),


### PR DESCRIPTION
PR for forms 2.2.0 release:

Added conditional forms fields that are configurable from the config files so that one field can do certain actions if another change. 

Breaking changes:
- names of config properties for setting options on selects, autocompletes, radio button & button toggles have changed.

Example:

```

{
          title: 'registerPoint',
          attribute: 'registerPoint',
          editType: EditType.Select,
          conditions: [
            {
              dependOn: 'incidentId',  // do actions on registerPoint if incidentId changes.
              enableIfHasValue: true, // field is only enabled if incidentId has a value.
              conditionalOptions: (incidentId: number) => { // reload select option whenever incidentId changes
                if (incidentId) {
                  return some observable based on incidentId
                }
                return of([]);
              },
            },
          ],
}
```
