### PR TITLE
feat: add date-time-field and alert-dialog components properties

### DIFF
--- a/projects/admin/src/lib/pages/admin-page/admin-page.component.html
+++ b/projects/admin/src/lib/pages/admin-page/admin-page.component.html
@@ -3,7 +3,16 @@
 </div>
 <div *ngIf="!error">
     <div class="admin-page">
-        <button *ngIf="schema.creatable" mat-raised-button color="primary" lab900TranslatableFormDialog [schema]="createForm" [submitFormHandler]="createHandler">Create</button>
+        <button 
+            *ngIf="schema.creatable" 
+            mat-raised-button color="primary" 
+            lab900TranslatableFormDialog 
+            [schema]="createForm" 
+            [dialogOptions]="dialogOptions"
+            [submitFormHandler]="createHandler"
+            >
+            Create
+        </button>
         <lab900-admin-table
                 [loading]="loading"
                 [schema]="schema"

--- a/projects/admin/src/lib/pages/translatable-admin-page/translatable-admin-page.component.html
+++ b/projects/admin/src/lib/pages/translatable-admin-page/translatable-admin-page.component.html
@@ -3,7 +3,18 @@
 </div>
 <div *ngIf="!error">
     <div class="admin-page">
-        <button *ngIf="schema.creatable" mat-raised-button color="primary" lab900TranslatableFormDialog [schema]="schema" [submitFormHandler]="createHandler" [create]="true" [getHandler]="getHandler">Create</button>
+        <button 
+            *ngIf="schema.creatable" 
+            mat-raised-button color="primary" 
+            lab900TranslatableFormDialog 
+            [schema]="schema" 
+            [dialogOptions]="dialogOptions" 
+            [submitFormHandler]="createHandler" 
+            [create]="true" 
+            [getHandler]="getHandler"
+            >
+            Create
+            </button>
         <lab900-translatable-admin-table
                 [loading]="loading"
                 [schema]="schema"

--- a/projects/forms/src/lib/components/form-dialog/form-dialog.component.html
+++ b/projects/forms/src/lib/components/form-dialog/form-dialog.component.html
@@ -4,5 +4,5 @@
 </mat-dialog-content>
 <mat-dialog-actions  align="end">
     <button mat-raised-button mat-dialog-close tabindex="-1">Cancel</button>
-    <button mat-raised-button color="primary" [disabled]="(!lab900Form.valid || loading || !!error)" (click)="submit(lab900Form.value)" tabindex="1">Ok</button>
+    <button mat-raised-button color="primary" [disabled]="(!lab900Form.valid || loading)" (click)="submit(lab900Form.value)" tabindex="1">Ok</button>
 </mat-dialog-actions>

--- a/projects/forms/src/lib/components/form-dialog/form-dialog.component.html
+++ b/projects/forms/src/lib/components/form-dialog/form-dialog.component.html
@@ -4,5 +4,5 @@
 </mat-dialog-content>
 <mat-dialog-actions  align="end">
     <button mat-raised-button mat-dialog-close tabindex="-1">Cancel</button>
-    <button mat-raised-button color="primary" [disabled]="loading" (click)="submit(lab900Form.valid, lab900Form.value)" tabindex="1">Ok</button>
+    <button mat-raised-button color="primary" [disabled]="(!lab900Form.valid || loading || !!error)" (click)="submit(lab900Form.value)" tabindex="1">Ok</button>
 </mat-dialog-actions>

--- a/projects/forms/src/lib/components/form-dialog/form-dialog.component.ts
+++ b/projects/forms/src/lib/components/form-dialog/form-dialog.component.ts
@@ -14,7 +14,6 @@ export class FormDialogComponent<T> {
 
   public dialogFormData: DialogFormData<T>;
   public loading = false;
-  public error: string;
 
   constructor(@Inject(MAT_DIALOG_DATA) private data: DialogFormData<T>, private dialogRef: MatDialogRef<FormDialogComponent<T>>) {
     this.dialogFormData = data;
@@ -22,11 +21,13 @@ export class FormDialogComponent<T> {
 
   submit(item: T) {
     this.loading = true;
-    this.error = null;
     this.dialogFormData
       .submit(item, this.formContainer?.form)
-      .catch((error) => (this.error = error))
-      .then((result) => (result ? this.dialogRef.close() : (this.error = 'Oops. An error occured.')))
+      .then((result) => {
+        if (result) {
+          this.dialogRef.close();
+        }
+      })
       .finally(() => (this.loading = false));
   }
 }

--- a/projects/forms/src/lib/components/form-dialog/form-dialog.component.ts
+++ b/projects/forms/src/lib/components/form-dialog/form-dialog.component.ts
@@ -16,25 +16,17 @@ export class FormDialogComponent<T> {
   public loading = false;
   public error: string;
 
-  constructor(
-    @Inject(MAT_DIALOG_DATA) private data: DialogFormData<T>,
-    private dialogRef: MatDialogRef<FormDialogComponent<T>>
-  ) {
+  constructor(@Inject(MAT_DIALOG_DATA) private data: DialogFormData<T>, private dialogRef: MatDialogRef<FormDialogComponent<T>>) {
     this.dialogFormData = data;
   }
 
-  submit(valid: boolean, item: T) {
-    if (valid) {
-      this.loading = true;
-      this.error = null;
-      this.dialogFormData
-        .submit(item)
-        .catch((error) => (this.error = error))
-        .then((result) => (result ? this.dialogRef.close() : (this.error = 'Oops. An error occured.')))
-        .finally(() => (this.loading = false));
-    } else if (!valid && this.data?.onInvalid) {
-      this.data?.onInvalid(this.formContainer?.form, item);
-    }
+  submit(item: T) {
+    this.loading = true;
+    this.error = null;
+    this.dialogFormData
+      .submit(item, this.formContainer?.form)
+      .catch((error) => (this.error = error))
+      .then((result) => (result ? this.dialogRef.close() : (this.error = 'Oops. An error occured.')))
+      .finally(() => (this.loading = false));
   }
-
 }

--- a/projects/forms/src/lib/components/form-fields/date-time-field/date-time-field.component.html
+++ b/projects/forms/src/lib/components/form-fields/date-time-field/date-time-field.component.html
@@ -13,7 +13,7 @@
     >
 
     <mat-datepicker-toggle [disabled]="fieldIsReadonly || fieldControl.disabled" matSuffix [for]="picker"></mat-datepicker-toggle>
-    <ngx-mat-datetime-picker #picker [disabled]="fieldIsReadonly || fieldControl.disabled" [showSpinners]="true" [showSeconds]="showSeconds" [startView]="startView"></ngx-mat-datetime-picker>
+    <ngx-mat-datetime-picker #picker [disabled]="fieldIsReadonly || fieldControl.disabled" [showSpinners]="true" [showSeconds]="showSeconds" [startView]="startView" [defaultTime]="defaultTime" [stepMinute]="stepMinute"></ngx-mat-datetime-picker>
     <mat-hint *ngIf="hint && !fieldIsReadonly  && !(schema.options.hint.hideHintOnValidValue && input.value)" translate>{{ hint }}</mat-hint>
     <mat-error *ngIf="!valid && !fieldIsReadonly">{{ getErrorMessage() | async }}</mat-error>
 </mat-form-field>

--- a/projects/forms/src/lib/components/form-fields/date-time-field/date-time-field.component.ts
+++ b/projects/forms/src/lib/components/form-fields/date-time-field/date-time-field.component.ts
@@ -30,4 +30,12 @@ export class DateTimeFieldComponent extends FormComponent<DatepickerFieldOptions
   public get minDate(): Date | null {
     return this.schema?.options?.minDate;
   }
+
+  public get defaultTime(): [number, number, number] | null {
+    return this.schema?.options?.defaultTime;
+  }
+
+  public get stepMinute(): number | 1 {
+    return this.schema?.options?.stepMinute || 1;
+  }
 }

--- a/projects/forms/src/lib/components/form-fields/input-field/input-field.component.html
+++ b/projects/forms/src/lib/components/form-fields/input-field/input-field.component.html
@@ -14,7 +14,9 @@
         [allowNegativeNumbers]="options?.fieldMask?.allowNegativeNumbers || false"
         [showMaskTyped]="options?.fieldMask?.showMaskedType || false"
     >
-    <mat-hint *ngIf="hint && !(schema.options.hint.hideHintOnValidValue && input.value) && !fieldIsReadonly">{{ hint | translate }}</mat-hint>
+    <mat-hint *ngIf="hint && !(schema.options.hint.hideHintOnValidValue && input.value) && !fieldIsReadonly">
+        {{ hint | translate }}<span *ngIf="schema.options.hint?.innerHTML" [innerHTML]="schema.options.hint.innerHTML"></span>
+    </mat-hint>
     <mat-hint align="end" *ngIf="options?.maxLength && !fieldIsReadonly">{{ input.value?.length || 0 }}/{{ options?.maxLength }}</mat-hint>
     <mat-error *ngIf="!valid && !fieldIsReadonly">{{ getErrorMessage() | async }}</mat-error>
     <lab900-icon [icon]="schema.icon" *ngIf="schema?.icon?.position === 'left'" matPrefix class="input-field__icon-left"></lab900-icon>

--- a/projects/forms/src/lib/models/FormField.ts
+++ b/projects/forms/src/lib/models/FormField.ts
@@ -81,6 +81,8 @@ export interface DatepickerFieldOptions extends FieldOptions {
   maxDate?: Date;
   minDate?: Date;
   showSeconds?: boolean;
+  defaultTime?: [number, number, number];
+  stepMinute?: number;
 }
 
 export interface DateRangePickerFieldOptions extends FieldOptions {

--- a/projects/forms/src/lib/models/FormField.ts
+++ b/projects/forms/src/lib/models/FormField.ts
@@ -20,7 +20,7 @@ export interface FieldMask {
 
 export interface FieldOptions {
   hide?: boolean | ((data?: any) => boolean);
-  hint?: { value: string; hideHintOnValidValue?: boolean };
+  hint?: { value: string; hideHintOnValidValue?: boolean; innerHTML?: string };
   placeholder?: string;
   colspan?: number; // 12 column grid = value from 1 to 12.
   mobileCols?: boolean; // keep colspan on mobile (only for form rows)

--- a/projects/forms/src/lib/models/dialogFormData.ts
+++ b/projects/forms/src/lib/models/dialogFormData.ts
@@ -4,6 +4,5 @@ import { FormGroup } from '@angular/forms';
 export interface DialogFormData<T> {
   schema: Form;
   data: T;
-  submit: (data: T) => Promise<boolean>;
-  onInvalid: (formGroup: FormGroup, data: T) => void;
+  submit: (data: T, formGroup: FormGroup) => Promise<boolean>;
 }

--- a/projects/ui/src/lib/dialog/components/alert-dialog/alert-dialog.component.html
+++ b/projects/ui/src/lib/dialog/components/alert-dialog/alert-dialog.component.html
@@ -1,5 +1,6 @@
 <mat-dialog-content>
     {{message | translate}}
+    <span [innerHTML]="innerHTML"></span>
 </mat-dialog-content>
 <mat-dialog-actions align="center">
     <button mat-raised-button color="primary" mat-dialog-close tabindex="-1">{{buttonText | translate}}</button>

--- a/projects/ui/src/lib/dialog/components/alert-dialog/alert-dialog.component.ts
+++ b/projects/ui/src/lib/dialog/components/alert-dialog/alert-dialog.component.ts
@@ -9,11 +9,13 @@ import { AlertDialog } from '../../models/alertDialog';
 })
 export class AlertDialogComponent {
   message = '';
+  innerHTML = '';
   buttonText = 'Ok';
   constructor(@Inject(MAT_DIALOG_DATA) private data: AlertDialog, private dialogRef: MatDialogRef<AlertDialogComponent>) {
     if (data) {
       this.message = data.message || this.message;
       this.buttonText = data.okButtonText || this.buttonText;
+      this.innerHTML = data.innerHTML || this.innerHTML;
     }
     this.dialogRef.updateSize('300vw', '300vw');
   }

--- a/projects/ui/src/lib/dialog/models/alertDialog.ts
+++ b/projects/ui/src/lib/dialog/models/alertDialog.ts
@@ -1,4 +1,5 @@
 export interface AlertDialog {
   message?: string;
   okButtonText?: string;
+  innerHTML?: string;
 }


### PR DESCRIPTION
## Purpose

To add new functionality to components,  date-time-field (@lab900/forms) and alert-dialog (@lab900/ui)

## Approach

New Properties:
date-time-field component
```
  defaultTime?: [number, number, number];
  stepMinute?: number;
```
alert-dialog component
```
innerHTML?: string;
```

I've also removed some added functionality from the previous release because some components were not working in the correct way.
removed: `onInvalid()` from `DialogFormData` and refactor the `submit()` function from `FormDialogComponent`

## Learning

I've used [npm link](https://docs.npmjs.com/cli/v6/commands/npm-link) and it worked as expected ❤️ 
