### PR TITLE
feat: allow to pass hint translation data and allow hint and error text to have inner html

### DIFF
--- a/projects/forms/src/lib/components/form-fields/autocomplete-field/autocomplete-field.component.html
+++ b/projects/forms/src/lib/components/form-fields/autocomplete-field/autocomplete-field.component.html
@@ -11,8 +11,8 @@
         placeholder="{{ placeholder | translate }}"
         type="text"
     >
-    <mat-hint *ngIf="hint && !fieldIsReadonly && !(schema.options.hint.hideHintOnValidValue && input.value)" translate>{{ hint }}</mat-hint>
-    <mat-error *ngIf="!valid && !fieldIsReadonly">{{ getErrorMessage() | async }}</mat-error>
+    <mat-hint *ngIf="hint && !fieldIsReadonly && !(schema.options.hint.hideHintOnValidValue && input.value)"><span [innerHTML]="hint | translate: hintValueTranslateData"></span></mat-hint>
+    <mat-error *ngIf="!valid && !fieldIsReadonly"><span [innerHTML]="getErrorMessage() | async "></span></mat-error>
     <mat-icon matSuffix *ngIf="!fieldIsReadonly">search</mat-icon>
     <mat-autocomplete #auto="matAutocomplete" [displayWith]="options.displayInputFn">
         <mat-option *ngFor="let option of filteredOptions | async" [value]="option?.value">

--- a/projects/forms/src/lib/components/form-fields/autocomplete-multiple-field/autocomplete-multiple-field.component.html
+++ b/projects/forms/src/lib/components/form-fields/autocomplete-multiple-field/autocomplete-multiple-field.component.html
@@ -1,7 +1,7 @@
 <mat-form-field [formGroup]="group" *ngIf="!fieldIsHidden" class="lab900-autocomplete-multi-field" id="lab900-autocomplete-multi-field-{{schema?.attribute}}">
     <mat-label *ngIf="schema.title" translate>{{ schema.title }}</mat-label>
-    <mat-hint *ngIf="hint && !fieldIsReadonly && !(schema.options.hint.hideHintOnValidValue && input.value)" translate>{{ hint }}</mat-hint>
-    <mat-error *ngIf="!valid && !fieldIsReadonly">{{ getErrorMessage() | async }}</mat-error>
+    <mat-hint *ngIf="hint && !fieldIsReadonly && !(schema.options.hint.hideHintOnValidValue && input.value)"><span [innerHTML]="hint | translate: hintValueTranslateData"></span></mat-hint>
+    <mat-error *ngIf="!valid && !fieldIsReadonly"><span [innerHTML]="getErrorMessage() | async "></span></mat-error>
     <mat-icon matSuffix *ngIf="!fieldIsReadonly">search</mat-icon>
     <mat-chip-list #chipList [formControlName]="schema.attribute">
         <mat-chip *ngFor="let opt of selectedOptions; let i = index" [removable]="!fieldIsReadonly" selectable (removed)="remove(i)">

--- a/projects/forms/src/lib/components/form-fields/checkbox-field/checkbox-field.component.html
+++ b/projects/forms/src/lib/components/form-fields/checkbox-field/checkbox-field.component.html
@@ -10,7 +10,7 @@
       {{schema.title | translate}}
     </mat-checkbox>
     <div *ngIf="!fieldIsReadonly" class="subscript-wrapper" [@transitionMessages]="valid ? 'void' : 'enter'">
-        <mat-hint *ngIf="hint && !(schema.options.hint.hideHintOnValidValue && checkbox.value)" translate>{{ hint }}</mat-hint>
-        <mat-error *ngIf="!valid">{{ getErrorMessage() | async }}</mat-error>
+        <mat-hint *ngIf="hint && !(schema.options.hint.hideHintOnValidValue && checkbox.value)"><span [innerHTML]="hint | translate: hintValueTranslateData"></span></mat-hint>
+        <mat-error *ngIf="!valid"><span [innerHTML]="getErrorMessage() | async "></span></mat-error>
     </div>
 </div>

--- a/projects/forms/src/lib/components/form-fields/date-field/date-field.component.html
+++ b/projects/forms/src/lib/components/form-fields/date-field/date-field.component.html
@@ -13,6 +13,6 @@
     >
     <mat-datepicker-toggle [disabled]="fieldIsReadonly || fieldControl.disabled" matSuffix [for]="picker"></mat-datepicker-toggle>
     <mat-datepicker [disabled]="fieldIsReadonly || fieldControl.disabled" #picker [startView]="startView"></mat-datepicker>
-    <mat-hint *ngIf="hint && !fieldIsReadonly  && !(schema.options.hint.hideHintOnValidValue && input.value)" translate>{{ hint }}</mat-hint>
-    <mat-error *ngIf="!valid && !fieldIsReadonly">{{ getErrorMessage() | async }}</mat-error>
+    <mat-hint *ngIf="hint && !fieldIsReadonly  && !(schema.options.hint.hideHintOnValidValue && input.value)"><span [innerHTML]="hint | translate: hintValueTranslateData"></span></mat-hint>
+    <mat-error *ngIf="!valid && !fieldIsReadonly"><span [innerHTML]="getErrorMessage() | async "></span></mat-error>
 </mat-form-field>

--- a/projects/forms/src/lib/components/form-fields/date-range-field/date-range-field.component.html
+++ b/projects/forms/src/lib/components/form-fields/date-range-field/date-range-field.component.html
@@ -6,6 +6,6 @@
     </mat-date-range-input>
     <mat-datepicker-toggle [disabled]="fieldIsReadonly || dateFormGroup.disabled" matSuffix [for]="picker"></mat-datepicker-toggle>
     <mat-date-range-picker [disabled]="fieldIsReadonly || dateFormGroup.disabled" #picker></mat-date-range-picker>
-    <mat-hint *ngIf="hint && !fieldIsReadonly  && !(schema.options.hint.hideHintOnValidValue && dateFormGroup.value)" translate>{{ hint }}</mat-hint>
-    <mat-error *ngIf="!valid && !fieldIsReadonly">{{ getErrorMessage() | async }}</mat-error>
+    <mat-hint *ngIf="hint && !fieldIsReadonly  && !(schema.options.hint.hideHintOnValidValue && dateFormGroup.value)"><span [innerHTML]="hint | translate: hintValueTranslateData"></span></mat-hint>
+    <mat-error *ngIf="!valid && !fieldIsReadonly"><span [innerHTML]="getErrorMessage() | async "></span></mat-error>
 </mat-form-field>

--- a/projects/forms/src/lib/components/form-fields/date-time-field/date-time-field.component.html
+++ b/projects/forms/src/lib/components/form-fields/date-time-field/date-time-field.component.html
@@ -14,6 +14,6 @@
 
     <mat-datepicker-toggle [disabled]="fieldIsReadonly || fieldControl.disabled" matSuffix [for]="picker"></mat-datepicker-toggle>
     <ngx-mat-datetime-picker #picker [disabled]="fieldIsReadonly || fieldControl.disabled" [showSpinners]="true" [showSeconds]="showSeconds" [startView]="startView" [defaultTime]="defaultTime" [stepMinute]="stepMinute"></ngx-mat-datetime-picker>
-    <mat-hint *ngIf="hint && !fieldIsReadonly  && !(schema.options.hint.hideHintOnValidValue && input.value)" translate>{{ hint }}</mat-hint>
-    <mat-error *ngIf="!valid && !fieldIsReadonly">{{ getErrorMessage() | async }}</mat-error>
+    <mat-hint *ngIf="hint && !fieldIsReadonly  && !(schema.options.hint.hideHintOnValidValue && input.value)"><span [innerHTML]="hint | translate: hintValueTranslateData"></span></mat-hint>
+    <mat-error *ngIf="!valid && !fieldIsReadonly"><span [innerHTML]="getErrorMessage() | async "></span></mat-error>
 </mat-form-field>

--- a/projects/forms/src/lib/components/form-fields/file-field/file-field.component.html
+++ b/projects/forms/src/lib/components/form-fields/file-field/file-field.component.html
@@ -3,6 +3,6 @@
     <lab900-mat-file-field [attr.disabled]="fieldIsReadonly" #fileField [formControlName]="schema.attribute"></lab900-mat-file-field>
     <mat-icon matSuffix class="flex">folder</mat-icon>
     <mat-icon *ngIf="!fileField.empty" matSuffix (click)="fileField.clear($event)">close</mat-icon>
-    <mat-hint *ngIf="hint" translate>{{ hint }}</mat-hint>
-    <mat-error *ngIf="!valid">{{ getErrorMessage() | async }}</mat-error>
+    <mat-hint *ngIf="hint"><span [innerHTML]="hint | translate: hintValueTranslateData"></span></mat-hint>
+    <mat-error *ngIf="!valid"><span [innerHTML]="getErrorMessage() | async "></span></mat-error>
 </mat-form-field>

--- a/projects/forms/src/lib/components/form-fields/input-field/input-field.component.html
+++ b/projects/forms/src/lib/components/form-fields/input-field/input-field.component.html
@@ -14,11 +14,11 @@
         [allowNegativeNumbers]="options?.fieldMask?.allowNegativeNumbers || false"
         [showMaskTyped]="options?.fieldMask?.showMaskedType || false"
     >
-    <mat-hint *ngIf="(hint || hintHTML) && !(schema.options.hint.hideHintOnValidValue && input.value) && !fieldIsReadonly">
-        {{ hint | translate }}<span *ngIf="hintHTML" [innerHTML]="hintHTML | translate"></span>
+    <mat-hint *ngIf="hint && !(schema.options.hint.hideHintOnValidValue && input.value) && !fieldIsReadonly">
+        <span [innerHTML]="hint | translate: hintValueTranslateData"></span>
     </mat-hint>
     <mat-hint align="end" *ngIf="options?.maxLength && !fieldIsReadonly">{{ input.value?.length || 0 }}/{{ options?.maxLength }}</mat-hint>
-    <mat-error *ngIf="!valid && !fieldIsReadonly">{{ getErrorMessage() | async }}</mat-error>
+    <mat-error *ngIf="!valid && !fieldIsReadonly"><span [innerHTML]="getErrorMessage() | async "></span></mat-error>
     <lab900-icon [icon]="schema.icon" *ngIf="schema?.icon?.position === 'left'" matPrefix class="input-field__icon-left"></lab900-icon>
     <lab900-icon [icon]="schema.icon" *ngIf="schema?.icon?.position === 'right'" matSuffix ></lab900-icon>
 </mat-form-field>

--- a/projects/forms/src/lib/components/form-fields/select-field/select-field.component.html
+++ b/projects/forms/src/lib/components/form-fields/select-field/select-field.component.html
@@ -15,8 +15,8 @@
             <ng-container *ngIf="!options?.displayOptionFn">{{ item.label | translate }}</ng-container>
         </mat-option>
     </mat-select>
-    <mat-hint *ngIf="hint && !(schema.options.hint.hideHintOnValidValue && select.value)">{{ hint | translate }}</mat-hint>
-    <mat-error *ngIf="!valid">{{ getErrorMessage() | async }}</mat-error>
+    <mat-hint *ngIf="hint && !(schema.options.hint.hideHintOnValidValue && select.value)"><span [innerHTML]="hint | translate: hintValueTranslateData"></span></mat-hint>
+    <mat-error *ngIf="!valid"><span [innerHTML]="getErrorMessage() | async "></span></mat-error>
 </mat-form-field>
 
 <div class="lab900-readonly-field" *ngIf="fieldIsReadonly && !fieldIsHidden">

--- a/projects/forms/src/lib/components/form-fields/textarea-field/textarea-field.component.html
+++ b/projects/forms/src/lib/components/form-fields/textarea-field/textarea-field.component.html
@@ -8,9 +8,9 @@
         matInput
         placeholder="{{ placeholder | translate }}"
     ></textarea>
-    <mat-hint *ngIf="hint && !fieldIsReadonly && !(schema.options.hint.hideHintOnValidValue && input.value)" translate>{{ hint }}</mat-hint>
+    <mat-hint *ngIf="hint && !fieldIsReadonly && !(schema.options.hint.hideHintOnValidValue && input.value)"><span [innerHTML]="hint | translate: hintValueTranslateData"></span></mat-hint>
     <mat-hint *ngIf="options?.maxLength && !fieldIsReadonly" align="end">
         {{ input.value?.length || 0 }}/{{ options?.maxLength }}
     </mat-hint>
-    <mat-error *ngIf="!valid && !fieldIsReadonly">{{ getErrorMessage() | async }}</mat-error>
+    <mat-error *ngIf="!valid && !fieldIsReadonly"><span [innerHTML]="getErrorMessage() | async "></span></mat-error>
 </mat-form-field>

--- a/projects/forms/src/lib/models/FormField.ts
+++ b/projects/forms/src/lib/models/FormField.ts
@@ -20,7 +20,7 @@ export interface FieldMask {
 
 export interface FieldOptions {
   hide?: boolean | ((data?: any) => boolean);
-  hint?: { value?: string; hideHintOnValidValue?: boolean; valueHTML?: string };
+  hint?: { value?: string; hideHintOnValidValue?: boolean; valueTranslateData?: object };
   placeholder?: string;
   colspan?: number; // 12 column grid = value from 1 to 12.
   mobileCols?: boolean; // keep colspan on mobile (only for form rows)

--- a/projects/forms/src/lib/models/IFormComponent.ts
+++ b/projects/forms/src/lib/models/IFormComponent.ts
@@ -51,8 +51,8 @@ export abstract class FormComponent<T extends FieldOptions = FieldOptions> imple
     return this.options?.hint?.value;
   }
 
-  public get hintHTML(): string {
-    return this.options?.hint?.valueHTML;
+  public get hintValueTranslateData(): object {
+    return this.options?.hint?.valueTranslateData;
   }
 
   public get placeholder(): string {


### PR DESCRIPTION
## Purpose

To allow to pass hint translation data and to allow hint and error text to have inner html.

## Approach

- All hint and error text in being injected into `<span [innerHTML]="..."></span>`
- Added `{options: {hint: {valueTranslateData : {...}}}}` prop to pass translations params