### PR TITLE
feat: add multi language TextArea field

### DIFF
--- a/projects/forms/src/lib/components/form-fields/multi-lang-input/multi-lang-field-control/multi-lang-field-control.component.html
+++ b/projects/forms/src/lib/components/form-fields/multi-lang-input/multi-lang-field-control/multi-lang-field-control.component.html
@@ -20,7 +20,7 @@
       <mat-form-field class="lab900-input-field">
         <mat-label *ngIf="label">{{ label | translate }}</mat-label>
         <input
-          *ngIf="!textAreaField"
+          *ngIf="!useTextAreaField"
           matInput
           type="text"
           (blur)="blur()"
@@ -31,7 +31,7 @@
           [ngClass]="{ readonly: readonly }"
         />
         <textarea
-          *ngIf="textAreaField"
+          *ngIf="useTextAreaField"
           matInput
           (blur)="blur()"
           [ngModel]="globalTranslation"
@@ -51,7 +51,7 @@
         >
           <mat-label *ngIf="label">{{ label | translate }}</mat-label>
           <input
-            *ngIf="!textAreaField"
+            *ngIf="!useTextAreaField"
             matInput
             type="text"
             (blur)="blur()"
@@ -62,7 +62,7 @@
             [ngClass]="{ readonly: readonly }"
           />
           <textarea
-            *ngIf="textAreaField"
+            *ngIf="useTextAreaField"
             matInput
             (blur)="blur()"
             [ngModel]="value && value[lang.value]"

--- a/projects/forms/src/lib/components/form-fields/multi-lang-input/multi-lang-field-control/multi-lang-field-control.component.html
+++ b/projects/forms/src/lib/components/form-fields/multi-lang-input/multi-lang-field-control/multi-lang-field-control.component.html
@@ -20,6 +20,7 @@
       <mat-form-field class="lab900-input-field">
         <mat-label *ngIf="label">{{ label | translate }}</mat-label>
         <input
+          *ngIf="!textAreaField"
           matInput
           type="text"
           (blur)="blur()"
@@ -29,6 +30,16 @@
           [readonly]="readonly"
           [ngClass]="{ readonly: readonly }"
         />
+        <textarea
+          *ngIf="textAreaField"
+          matInput
+          (blur)="blur()"
+          [ngModel]="globalTranslation"
+          (ngModelChange)="updateGlobalTranslation($event)"
+          [required]="required"
+          [readonly]="readonly"
+          [ngClass]="{ readonly: readonly }"
+        ></textarea>
       </mat-form-field>
     </div>
     <div *ngIf="translate">
@@ -40,6 +51,7 @@
         >
           <mat-label *ngIf="label">{{ label | translate }}</mat-label>
           <input
+            *ngIf="!textAreaField"
             matInput
             type="text"
             (blur)="blur()"
@@ -49,6 +61,16 @@
             [readonly]="readonly"
             [ngClass]="{ readonly: readonly }"
           />
+          <textarea
+            *ngIf="textAreaField"
+            matInput
+            (blur)="blur()"
+            [ngModel]="value && value[lang.value]"
+            (ngModelChange)="updateSingleLanguage($event, lang.value)"
+            [required]="required"
+            [readonly]="readonly"
+            [ngClass]="{ readonly: readonly }"
+          ></textarea>
         </mat-form-field>
       </ng-container>
     </div>

--- a/projects/forms/src/lib/components/form-fields/multi-lang-input/multi-lang-field-control/multi-lang-field-control.component.ts
+++ b/projects/forms/src/lib/components/form-fields/multi-lang-input/multi-lang-field-control/multi-lang-field-control.component.ts
@@ -39,7 +39,7 @@ export class MultiLangFieldControlComponent extends BaseControlValueAccessorDire
   public stopTranslateLabel?: string;
 
   @Input()
-  public textAreaField = false;
+  public useTextAreaField = false;
 
   public activeLanguage?: ValueLabel;
 

--- a/projects/forms/src/lib/components/form-fields/multi-lang-input/multi-lang-field-control/multi-lang-field-control.component.ts
+++ b/projects/forms/src/lib/components/form-fields/multi-lang-input/multi-lang-field-control/multi-lang-field-control.component.ts
@@ -38,6 +38,9 @@ export class MultiLangFieldControlComponent extends BaseControlValueAccessorDire
   @Input()
   public stopTranslateLabel?: string;
 
+  @Input()
+  public textAreaField = false;
+
   public activeLanguage?: ValueLabel;
 
   public globalTranslation: string;

--- a/projects/forms/src/lib/components/form-fields/multi-lang-input/multi-lang-input-field.component.html
+++ b/projects/forms/src/lib/components/form-fields/multi-lang-input/multi-lang-input-field.component.html
@@ -15,7 +15,7 @@
     [buttonColor]="options?.buttonColor"
     [translateLabel]="options?.translateLabel"
     [stopTranslateLabel]="options?.stopTranslateLabel"
-    [textAreaField]="options?.textAreaField"
+    [useTextAreaField]="options?.useTextAreaField"
   ></lab900-multi-lang-field-control>
   <div *ngIf="!valid && fieldControl.touched && !fieldIsReadonly">
     <mat-error>{{ getErrorMessage() | async }}</mat-error>

--- a/projects/forms/src/lib/components/form-fields/multi-lang-input/multi-lang-input-field.component.html
+++ b/projects/forms/src/lib/components/form-fields/multi-lang-input/multi-lang-input-field.component.html
@@ -15,6 +15,7 @@
     [buttonColor]="options?.buttonColor"
     [translateLabel]="options?.translateLabel"
     [stopTranslateLabel]="options?.stopTranslateLabel"
+    [textAreaField]="options?.textAreaField"
   ></lab900-multi-lang-field-control>
   <div *ngIf="!valid && fieldControl.touched && !fieldIsReadonly">
     <mat-error>{{ getErrorMessage() | async }}</mat-error>

--- a/projects/forms/src/lib/models/FormField.ts
+++ b/projects/forms/src/lib/models/FormField.ts
@@ -53,7 +53,7 @@ export interface MultiLangInputFieldOptions extends InputFieldOptions {
   buttonColor?: ThemePalette;
   translateLabel?: string;
   stopTranslateLabel?: string;
-  textAreaField?: boolean;
+  useTextAreaField?: boolean;
 }
 
 export interface RepeaterFieldOptions extends FieldOptions {

--- a/projects/forms/src/lib/models/FormField.ts
+++ b/projects/forms/src/lib/models/FormField.ts
@@ -53,6 +53,7 @@ export interface MultiLangInputFieldOptions extends InputFieldOptions {
   buttonColor?: ThemePalette;
   translateLabel?: string;
   stopTranslateLabel?: string;
+  textAreaField?: boolean;
 }
 
 export interface RepeaterFieldOptions extends FieldOptions {

--- a/src/app/modules/showcase-forms/examples/form-field-multi-language-example/form-field-multi-language-example.component.ts
+++ b/src/app/modules/showcase-forms/examples/form-field-multi-language-example/form-field-multi-language-example.component.ts
@@ -42,6 +42,18 @@ export class FormFieldMultiLanguageExampleComponent {
           missingTranslations: 'missing translations',
         },
       },
+      {
+        attribute: 'multiLangField4',
+        title: 'Multi language field (TextArea)',
+        editType: EditType.MultiLangInput,
+        validators: [multiLanguageValidator()],
+        options: {
+          textAreaField: true,
+        },
+        errorMessages: {
+          missingTranslations: 'missing translations',
+        },
+      },
     ],
   };
 

--- a/src/app/modules/showcase-forms/examples/form-field-multi-language-example/form-field-multi-language-example.component.ts
+++ b/src/app/modules/showcase-forms/examples/form-field-multi-language-example/form-field-multi-language-example.component.ts
@@ -48,7 +48,7 @@ export class FormFieldMultiLanguageExampleComponent {
         editType: EditType.MultiLangInput,
         validators: [multiLanguageValidator()],
         options: {
-          textAreaField: true,
+          useTextAreaField: true,
         },
         errorMessages: {
           missingTranslations: 'missing translations',


### PR DESCRIPTION
## Purpose

To add multi language text-area field

## Approach

- added a new option `useTextAreaField` to the `MultiLangInputFieldComponent` in order to use a `textarea` instead of `input` component.

![Screenshot 2021-06-09 at 09 30 46](https://user-images.githubusercontent.com/77984527/121312268-821ead00-c905-11eb-8b5e-328c7bfa417a.png)
![Screenshot 2021-06-09 at 09 30 57](https://user-images.githubusercontent.com/77984527/121312291-85199d80-c905-11eb-97b6-937836b7aec1.png)
![Screenshot 2021-06-09 at 09 31 17](https://user-images.githubusercontent.com/77984527/121312295-86e36100-c905-11eb-94d9-fa42e1e5af27.png)
![Screenshot 2021-06-09 at 09 31 26](https://user-images.githubusercontent.com/77984527/121312304-88148e00-c905-11eb-90f8-2e5a9fa58c0e.png)


#### Pre-Merge TODOs
- [x] depends on https://github.com/lab900/angular-libraries/pull/107
