### PR TITLE
Long strings and positioning can be fixed with cellClass

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -3,4 +3,5 @@ module.exports = {
   singleQuote: true,
   trailingComma: 'all',
   printWidth: 140,
+  endOfLine: "auto"
 };

--- a/projects/ui/src/lib/table/components/table-cell-value/table-cell-value.component.ts
+++ b/projects/ui/src/lib/table/components/table-cell-value/table-cell-value.component.ts
@@ -4,11 +4,18 @@ import { TableCell } from '../../models/table-cell.model';
 @Component({
   selector: 'lab900-table-cell-value',
   template: ` <ng-container *ngIf="cell && cellValue">
-    <span *ngIf="!cell.click" class="lab900-table__tooltip">
-      <span class="lab900-table__tooltipText" *ngIf="getMatTooltip()">{{ getMatTooltip() }}</span>
+    <span *ngIf="!cell.click" [matTooltipClass]="'lab900-table__mat-tooltip'" [matTooltip]="getMatTooltip()">
       {{ cellValue | translate }}
     </span>
-    <a style="cursor: pointer" *ngIf="cell.click" (click)="cell.click(data, cell)">{{ cellValue | translate }}</a>
+    <a
+      style="cursor: pointer"
+      *ngIf="cell.click"
+      (click)="cell.click(data, cell)"
+      [matTooltipClass]="'lab900-table__mat-tooltip'"
+      [matTooltip]="getMatTooltip()"
+    >
+      {{ cellValue | translate }}
+    </a>
   </ng-container>`,
 })
 export class Lab900TableCellValueComponent<T = any> implements OnChanges {

--- a/projects/ui/src/lib/table/components/table/table.component.scss
+++ b/projects/ui/src/lib/table/components/table/table.component.scss
@@ -63,46 +63,4 @@
   &__mat-tooltip {
     min-width: fit-content;
   }
-
-  .lab900-table__tooltip {
-    position: relative;
-    display: inline-block;
-  }
-
-  .lab900-table__tooltip .lab900-table__tooltipText {
-    display: none;
-    background-color: #555;
-    color: #fff;
-    text-align: center;
-    border-radius: 6px;
-    padding: 5px 10px;
-    position: absolute;
-    z-index: 1;
-    top: 150%;
-    left: 60px;
-    margin-left: -60px;
-    width: fit-content;
-    word-wrap: break-word;
-    white-space: normal;
-    max-width: 500px;
-    @media screen and (max-width: 599px) {
-      max-width: 110px;
-    }
-  }
-
-  .lab900-table__tooltip .lab900-table__tooltipText::after {
-    content: "";
-    position: absolute;
-    bottom: 100%;
-    left: 15px;
-    margin-left: -5px;
-    border-width: 5px;
-    border-style: solid;
-    border-color: transparent transparent #555 transparent;
-    white-space: normal;
-  }
-
-  .lab900-table__tooltip:hover .lab900-table__tooltipText {
-    display: unset;
-  }
 }


### PR DESCRIPTION
Reason for reverting:
- Long strings ovreflow and positioning can be fixed with cellClass in project > for this a PR will be created in the STIP project
- be consistent with other tooltips (now they are all mat tooltips)
- fixes issue with overlay not showing correctly out of container div (think bottom row of table)